### PR TITLE
[대기열] Redis 기반 실시간 대기열 시스템 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,18 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // ✅ Redisson, WebSocket 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.redisson:redisson-spring-boot-starter:3.40.0'
+
+    // Testcontainers를 JUnit5 환경에서 사용하기 위한 라이브러리
+    testImplementation 'org.testcontainers:junit-jupiter'
+    // Testcontainers로 Redis 컨테이너를 쉽게 띄우기 위한 라이브러리
+    testImplementation 'com.redis:testcontainers-redis:2.2.4'
+    // 비동기 테스트(Pub/Sub 등)에서 특정 조건이 만족될 때까지 기다리게 해주는 유틸리티
+    testImplementation 'org.awaitility:awaitility'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team03/ticketmon/_global/config/WebSocketConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/WebSocketConfig.java
@@ -1,0 +1,33 @@
+package com.team03.ticketmon._global.config;
+
+import com.team03.ticketmon.websocket.handler.CustomWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+/**
+ * WebSocket 관련 설정을 구성하는 클래스입니다.
+ */
+@Configuration
+@EnableWebSocket // WebSocket 활성화
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final CustomWebSocketHandler customWebSocketHandler;
+
+    /**
+     * WebSocket 핸들러를 특정 경로에 등록합니다.
+     *
+     * @param registry 핸들러를 등록할 레지스트리
+     */
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        // 클라이언트가 "/ws/waitqueue" 경로로 WebSocket 연결을 맺을 수 있도록 핸들러를 매핑합니다.
+        registry.addHandler(customWebSocketHandler, "/ws/waitqueue")
+                // TODO: [보안] 운영 환경에서는 CSRF 공격 등을 방지하기 위해 "*" 대신
+                // 실제 서비스 도메인(예: "https://ticketmon.com")을 명시해야 합니다.
+                .setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/com/team03/ticketmon/queue/controller/WaitingQueueController.java
+++ b/src/main/java/com/team03/ticketmon/queue/controller/WaitingQueueController.java
@@ -1,0 +1,63 @@
+package com.team03.ticketmon.queue.controller;
+
+import com.team03.ticketmon.queue.dto.EnterRequest;
+import com.team03.ticketmon.queue.service.WaitingQueueService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 대기열 시스템의 API 엔드포인트를 제공하는 컨트롤러입니다.
+ * 클라이언트는 이 컨트롤러를 통해 대기열에 진입을 요청할 수 있습니다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/queue")
+@RequiredArgsConstructor
+public class WaitingQueueController {
+
+    private final WaitingQueueService waitingQueueService;
+
+    /**
+     * [POST /api/queue/enter]
+     * 사용자를 특정 콘서트의 대기열에 등록합니다.
+     * 성공 시, 사용자의 현재 대기 순번을 포함한 상태 정보를 반환합니다.
+     *
+     * @param request 클라이언트로부터 받은 대기열 진입 요청 데이터 (concertId, userId)
+     * @return HTTP 200 OK와 함께 대기열 상태 정보(userId, rank, status)를 담은 응답
+     */
+    @PostMapping("/enter")
+    public ResponseEntity<Map<String, Object>> enterQueue(@RequestBody EnterRequest request) {
+        // TODO: [보안] 현재는 요청 본문(request body)에서 userId를 직접 받지만, 이는 매우 위험합니다.
+        // 실제 운영 환경에서는 반드시 Spring Security의 Authentication 객체(예: @AuthenticationPrincipal)에서
+        // 인증된 사용자 정보를 가져와 사용해야 합니다.
+        String userId = request.userId();
+        Long concertId = request.concertId();
+
+        // 어떤 요청이 들어왔는지 INFO 레벨로 기록합니다. API 트래픽 모니터링에 필수적입니다.
+        log.info("대기열 진입 요청 수신. 사용자 ID: {}, 콘서트 ID: {}", userId, concertId);
+
+        // 핵심 비즈니스 로직 호출
+        Long rank = waitingQueueService.apply(concertId, userId);
+
+        // TODO: [개선점] 응답 형식이 복잡해질 경우, Map 대신 전용 응답 DTO(예: EnterResponse.java)를
+        // 생성하여 사용하는 것이 타입 안정성과 코드 가독성 면에서 더 좋습니다.
+        Map<String, Object> response = Map.of(
+                "userId", userId,
+                "rank", rank,
+                "status", "WAITING"
+        );
+
+        // 개발 환경에서 어떤 응답을 반환하는지 상세히 확인하기 위한 DEBUG 레벨 로그.
+        // 운영 배포 시에는 로그 레벨을 INFO로 조정하여 이 로그가 출력되지 않도록 해야 합니다.
+        log.debug("대기열 진입 응답: {}", response);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/team03/ticketmon/queue/dto/AdmissionEvent.java
+++ b/src/main/java/com/team03/ticketmon/queue/dto/AdmissionEvent.java
@@ -1,0 +1,9 @@
+package com.team03.ticketmon.queue.dto;
+
+/**
+ * 사용자에게 입장 허가를 알리기 위해 Redis Pub/Sub 채널로 전송되는 DTO
+ *
+ * @param userId    입장 허가를 받은 사용자 ID
+ * @param accessKey 사용자에게 부여된, 서비스 접근 시 필요한 고유 키
+ */
+public record AdmissionEvent(String userId, String accessKey) {}

--- a/src/main/java/com/team03/ticketmon/queue/dto/EnterRequest.java
+++ b/src/main/java/com/team03/ticketmon/queue/dto/EnterRequest.java
@@ -1,0 +1,10 @@
+package com.team03.ticketmon.queue.dto;
+
+/**
+ * 클라이언트가 대기열 진입을 요청할 때 사용하는 DTO
+ *
+ * @param concertId 진입을 원하는 콘서트의 고유 ID
+ * @param userId    요청하는 사용자의 고유 ID (실제 운영에서는 보안을 위해 인증된 사용자 정보로 대체되어야 합니다)
+ */
+public record EnterRequest(Long concertId, String userId) {
+}

--- a/src/main/java/com/team03/ticketmon/queue/scheduler/CleanupScheduler.java
+++ b/src/main/java/com/team03/ticketmon/queue/scheduler/CleanupScheduler.java
@@ -1,0 +1,39 @@
+package com.team03.ticketmon.queue.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CleanupScheduler {
+
+    private final RedissonClient redissonClient;
+    private static final String ACTIVE_USERS_COUNT_KEY = "active_users_count";
+    private static final String ACTIVE_SESSIONS_KEY = "active_sessions";
+
+
+    @Scheduled(fixedDelay = 10000)
+    public void cleanupExpiredSessions() {
+        log.info("===== CleanupScheduler - 만료된 세션 정리 작업 시작=====");
+
+        // 1. active_sessions Set을 가져온다.
+        RScoredSortedSet<String> activeSessions = redissonClient.getScoredSortedSet(ACTIVE_SESSIONS_KEY);
+
+        // 2. 현재 시간보다 점수(만료 시간)가 낮은 모든 멤버를 찾아 삭제한다.
+        int expiredCount = activeSessions.removeRangeByScore(0, true, System.currentTimeMillis(), true);
+
+        if (expiredCount > 0) {
+            // 3. 삭제된 수만큼 활성 사용자 수를 감소시킨다.
+            long newCount = redissonClient.getAtomicLong(ACTIVE_USERS_COUNT_KEY).addAndGet(-expiredCount);
+            log.info("{}개의 만료된 세션을 정리했습니다. 현재 활성 사용자 수: {}", expiredCount, newCount);
+        } else {
+            log.info("만료된 세션이 없습니다.");
+        }
+        log.info("===== CleanupScheduler - 만료된 세션 정리 작업 종료=====");
+    }
+}

--- a/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
+++ b/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
@@ -1,0 +1,116 @@
+package com.team03.ticketmon.queue.scheduler;
+
+import com.team03.ticketmon.queue.service.NotificationService;
+import com.team03.ticketmon.queue.service.WaitingQueueService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RBucket;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 주기적으로 대기열을 확인하여 입장 가능 인원을 처리하는 스케줄러입니다.
+ * 이 스케줄러는 시스템의 처리량을 조절하는 핵심적인 역할을 담당합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WaitingQueueScheduler {
+
+    private static final String ACTIVE_SESSIONS_KEY = "active_sessions";
+    private final WaitingQueueService waitingQueueService;
+    private final RedissonClient redissonClient;
+    private final NotificationService notificationService;
+
+    @Value("${app.max-active-users}")
+    private long maxActiveUsers; // 시스템이 동시에 수용 가능한 최대 활성 사용자 수
+    @Value("${app.access-key-ttl-minutes}")
+    private long accessKeyTtlMinutes; // 발급된 입장 허가 키의 유효 시간 (분)
+
+    private static final String ACCESS_KEY_PREFIX = "accesskey:"; // 사용자별 입장 허가 키 (String)
+    private static final String ACTIVE_USERS_COUNT_KEY = "active_users_count"; // 현재 활성 사용자 수 (AtomicLong)
+
+    // TODO: 현재는 단일 콘서트를 가정하여 ID를 1L로 고정했지만, 향후 여러 콘서트를 지원하려면 이 로직을 동적으로 변경해야함
+    private static final long CONCERT_ID = 1L;
+
+
+    /**
+     * 10초마다 주기적으로 실행되어 대기열을 처리합니다.
+     * fixedDelay는 이전 작업이 끝난 후 10초를 기다리는 것을 의미합니다.
+     */
+    @Scheduled(fixedDelay = 10000)
+    public void execute() {
+        log.info("===== 대기열 스케줄러 실행 시작 =====");
+
+        // 현재 시스템의 활성 사용자 수를 Redis에서 조회
+        RAtomicLong activeUsersCount = redissonClient.getAtomicLong(ACTIVE_USERS_COUNT_KEY);
+        long currentActiveUsers = activeUsersCount.get();
+
+        // 입장 가능한 빈자리(slot)를 계산
+        long availableSlots = maxActiveUsers - currentActiveUsers;
+
+//        log.debug("활성 사용자 현황: {} / {} (빈자리: {})", currentActiveUsers, maxActiveUsers, availableSlots);
+        log.info("활성 사용자 현황: {} / {} (빈자리: {})", currentActiveUsers, maxActiveUsers, availableSlots);
+
+        if (availableSlots <= 0) {
+            log.info("===== 입장 가능한 자리가 없습니다. 스케줄러 작업을 종료 =====");
+            return;
+        }
+
+
+        // 대기열에서 빈자리 수만큼 사용자를 추출
+        List<String> admittedUsers = waitingQueueService.poll(CONCERT_ID, (int) availableSlots);
+
+        if (admittedUsers.isEmpty()) {
+            log.info("===== 새로 입장할 대기 인원이 없습니다. 스케줄러 작업을 종료 =====");
+            return;
+        }
+
+        // 추출된 사용자들에게 입장을 허가
+        grantAccessToUsers(admittedUsers);
+
+        log.info("===== 대기열 스케줄러 실행 종료 =====");
+    }
+
+    /**
+     * 입장 허가된 사용자들에게 고유 키를 발급하고, 알림을 전송한 후, 활성 사용자 수를 업데이트합니다.
+     *
+     * @param admittedUsers 입장 허가된 사용자 ID 리스트
+     */
+    private void grantAccessToUsers(List<String> admittedUsers) {
+        log.info("{}명의 신규 사용자 입장 처리 시작: {}", admittedUsers.size(), admittedUsers);
+
+        RScoredSortedSet<String> activeSessions = redissonClient.getScoredSortedSet(ACTIVE_SESSIONS_KEY);
+        long expiryTimestamp = System.currentTimeMillis() + accessKeyTtlMinutes * 60 * 1000;
+
+
+        for (String userId : admittedUsers) {
+            // 1. 사용자별로 예측 불가능한 고유 AccessKey를 발급
+            String accessKey = UUID.randomUUID().toString();
+            RBucket<String> accessKeyBucket = redissonClient.getBucket(ACCESS_KEY_PREFIX + userId);
+
+            // 2. Redis에 AccessKey를 TTL(Time-To-Live)과 함께 저장하여 일정 시간 후 자동 만료되도록
+            accessKeyBucket.set(accessKey, Duration.ofMinutes(accessKeyTtlMinutes));
+//            log.debug("사용자 '{}'에게 접근 키 발급 및 저장 완료 (유효 시간: {}분)", userId, accessKeyTtlMinutes);
+            log.info("사용자 '{}'에게 접근 키 발급 및 저장 완료 (유효 시간: {}분)", userId, accessKeyTtlMinutes);
+
+            // 3. 만료 시간을 점수로 하여 active_sessions Set에 추가
+            activeSessions.add(expiryTimestamp, userId);
+
+            // 4. Redis Pub/Sub을 통해 해당 사용자에게 입장하라는 알림을 발행
+            notificationService.sendAdmissionNotification(userId, accessKey);
+        }
+
+        // 4. 입장시킨 사용자 수만큼 활성 사용자 수를 원자적으로 증가시킵니다.
+        long totalActiveUsers = redissonClient.getAtomicLong(ACTIVE_USERS_COUNT_KEY).addAndGet(admittedUsers.size());
+        log.info("{}명 입장 완료. 현재 총 활성 사용자 수: {}", admittedUsers.size(), totalActiveUsers);
+    }
+}

--- a/src/main/java/com/team03/ticketmon/queue/service/NotificationService.java
+++ b/src/main/java/com/team03/ticketmon/queue/service/NotificationService.java
@@ -1,0 +1,53 @@
+package com.team03.ticketmon.queue.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team03.ticketmon.queue.dto.AdmissionEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RTopic;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+/**
+ * Redis Pub/Sub을 사용하여 입장 알림 메시지를 발행(Publish)하는 서비스.
+ * 이 서비스를 통해 스케줄러와 웹소켓 핸들러 간의 의존성을 분리.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final RedissonClient redissonClient;
+    private final ObjectMapper objectMapper;
+    private static final String ADMISSION_TOPIC = "admission-channel";
+
+    /**
+     * 특정 사용자에게 발급된 입장 허가 키를 담아 알림 이벤트를 발행.
+     *
+     * @param userId    알림을 받을 사용자 ID
+     * @param accessKey 사용자에게 부여된 고유 입장 허가 키
+     */
+    public void sendAdmissionNotification(String userId, String accessKey) {
+        AdmissionEvent event = new AdmissionEvent(userId, accessKey);
+        try {
+            // 1. 이벤트 객체를 JSON 문자열로 직렬화
+            String message = objectMapper.writeValueAsString(event);
+
+//            log.debug("입장 알림 발행 준비. 채널: {}, 메시지: {}", ADMISSION_TOPIC, message);
+            log.info("입장 알림 발행 준비. 채널: {}, 메시지: {}", ADMISSION_TOPIC, message);
+
+            // 2. Redis의 특정 토픽(채널)을 가져옴
+            RTopic topic = redissonClient.getTopic(ADMISSION_TOPIC);
+
+            // 3. 해당 토픽을 구독(Subscribe)하고 있는 모든 클라이언트에게 메시지를 발행
+            long receivers = topic.publish(message);
+
+            // 애플리케이션의 중요 상태 변경이므로 INFO 레벨로 기록
+            log.info("입장 알림 발행 완료. 사용자: {}, 채널: {}, 수신자 수: {}", userId, ADMISSION_TOPIC, receivers);
+        } catch (JsonProcessingException e) {
+            // 객체 직렬화는 프로그램 로직 오류일 가능성이 높으므로 ERROR 레벨로 기록
+            log.error("AdmissionEvent 객체 JSON 직렬화 실패! userId: {}", userId, e);
+        }
+    }
+}

--- a/src/main/java/com/team03/ticketmon/queue/service/WaitingQueueService.java
+++ b/src/main/java/com/team03/ticketmon/queue/service/WaitingQueueService.java
@@ -1,0 +1,92 @@
+package com.team03.ticketmon.queue.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Redis Sorted Set을 이용해 콘서트 대기열을 관리하는 서비스입니다.
+ * 이 서비스는 대기열 추가, 순위 조회, 사용자 추출 등의 핵심 기능을 담당하며,
+ * 모든 연산은 원자성(Atomic)을 보장해야 합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WaitingQueueService {
+
+    private final RedissonClient redissonClient;
+    private static final String QUEUE_KEY_PREFIX = "waitqueue:";
+
+    /**
+     * 특정 콘서트의 대기열에 사용자를 추가하고, 현재 대기 순번을 반환합니다.
+     * 이미 대기열에 있는 사용자가 재요청 시, 순위는 변동되지 않습니다(멱등성 보장).
+     *
+     * @param concertId 대기열을 식별하는 콘서트 ID
+     * @param userId    대기열에 추가할 사용자 ID
+     * @return 1부터 시작하는 사용자의 대기 순번
+     */
+    public Long apply(Long concertId, String userId) {
+        String queueKey = generateKey(concertId);
+        RScoredSortedSet<String> queue = redissonClient.getScoredSortedSet(queueKey);
+
+        // [핵심] 현재 시간을 점수(score)로 사용하여 사용자를 추가
+        boolean isNewUser = queue.addIfAbsent(System.currentTimeMillis(), userId);
+
+//        log.debug("대기열 신청 시도. 사용자: {}, 신규: {}, 대기열 키: {}", userId, isNewUser, queueKey);
+        log.info("대기열 신청 시도. 사용자: {}, 신규: {}, 대기열 키: {}", userId, isNewUser, queueKey);
+
+        Integer rankIndex = queue.rank(userId);
+
+        if (rankIndex == null) {
+            log.error("대기열 순위 조회 실패! 사용자가 정상적으로 추가되지 않았을 수 있습니다. 사용자: {}, 대기열 키: {}", userId, queueKey);
+            throw new IllegalStateException("대기열 순위를 조회할 수 없습니다.");
+        }
+
+        // Redis의 rank는 0부터 시작, 사용자에게 친숙한 1-based 순위로 변환하여 반환
+        return rankIndex.longValue() + 1;
+    }
+
+    /**
+     * 대기열에서 가장 오래 기다린 사용자를 지정된 수만큼 추출(제거 후 반환).
+     * 이 작업은 원자적으로(atomically) 이루어집니다.
+     *
+     * @param concertId 콘서트 ID
+     * @param count     입장시킬 사용자 수
+     * @return 입장 처리된 사용자 ID 리스트 (순서 보장)
+     */
+    public List<String> poll(Long concertId, int count) {
+        RScoredSortedSet<String> queue = redissonClient.getScoredSortedSet(generateKey(concertId));
+
+        // pollFirst(count)는 가장 점수가 낮은(오래된) N개의 원소를 Set에서 원자적으로 제거하고 반환
+        Collection<String> polledItems = queue.pollFirst(count);
+
+        // Collection을 List로 변환하여 반환 (일반적으로 순서가 보장됨)
+        return new ArrayList<>(polledItems);
+    }
+
+    /**
+     * 현재 대기열에 남아있는 총인원 수를 반환합니다.
+     * @param concertId 콘서트 ID
+     * @return 대기 인원 수
+     */
+    public Long getWaitingCount(Long concertId) {
+        RScoredSortedSet<String> queue = redissonClient.getScoredSortedSet(generateKey(concertId));
+        return (long) queue.size();
+    }
+
+    /**
+     * 콘서트 ID를 기반으로 Redis에서 사용할 고유 키를 생성합니다.
+     *
+     * @param concertId 콘서트 ID
+     * @return "waitqueue:{concertId}" 형식의 Redis 키
+     */
+    private String generateKey(Long concertId) {
+        return QUEUE_KEY_PREFIX + concertId;
+    }
+}

--- a/src/main/java/com/team03/ticketmon/websocket/handler/CustomWebSocketHandler.java
+++ b/src/main/java/com/team03/ticketmon/websocket/handler/CustomWebSocketHandler.java
@@ -1,0 +1,127 @@
+package com.team03.ticketmon.websocket.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomWebSocketHandler extends TextWebSocketHandler {
+
+    // 동시성 이슈를 방지 목적, 스레드에 안전한 콜렉션 사용
+    private final Map<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 클라이언트와 WebSocket 연결이 성공적으로 맺어졌을 때 호출
+     *
+     * @param session 새로 연결된 클라이언트의 세션
+     */
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        String userId = extractUserId(session);
+        if (userId != null) {
+            sessions.put(userId, session);
+            log.info("WebSocket 연결됨. 사용자: {}, 세션 ID: {}", userId, session.getId());
+        } else {
+            // WARN 레벨: 비정상적인 접근 시도일 수 있으므로 경고 로그
+            log.warn("사용자 ID 없이 WebSocket 연결 시도됨. 세션 ID: {}, URI: {}", session.getId(), session.getUri());
+        }
+    }
+
+    /**
+     * 텍스트 메시지를 수신했을 때 호출됩니다.
+     * 현재 시스템에서는 클라이언트로부터 메시지를 받는 로직은 없지만, 향후 확장을 위해 남겨둡니다.
+     * (예: 클라이언트가 "ping"을 보내 연결을 유지하는 로직)
+     * * @param session 메시지를 보낸 클라이언트의 세션
+     * @param message 수신된 텍스트 메시지
+     */
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String userId = extractUserId(session);
+//        log.debug("메시지 수신. 사용자: {}, 내용: {}", userId, message.getPayload());
+        log.info("메시지 수신. 사용자: {}, 내용: {}", userId, message.getPayload());
+        // 여기에 클라이언트가 보낸 메시지를 처리하는 로직 추가 가능
+    }
+
+    /**
+     * 클라이언트와 WebSocket 연결이 끊어졌을 때 호출됩니다.
+     *
+     * @param session 연결이 끊어진 클라이언트의 세션
+     * @param status  연결 종료 상태 (코드 및 원인)
+     */
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        String userId = extractUserId(session);
+        if (userId != null) {
+            sessions.remove(userId);
+            log.info("WebSocket 연결 종료됨. 사용자: {}, 세션 ID: {}, 상태: {}", userId, session.getId(), status);
+        }
+    }
+
+    /**
+     * 특정 사용자에게 메시지(Payload)를 전송
+     *
+     * @param userId  메시지를 받을 사용자 ID
+     * @param payload 전송할 데이터 (Map 형태, JSON으로 변환됨)
+     */
+    public void sendMessageToUser(String userId, Map<String, Object> payload) {
+        WebSocketSession session = sessions.get(userId);
+        if (session != null && session.isOpen()) {
+            try {
+                String message = objectMapper.writeValueAsString(payload);
+                session.sendMessage(new TextMessage(message));
+                log.info("메시지 전송 성공. 사용자: {}, 내용: {}", userId, message);
+            } catch (IOException e) {
+                log.error("WebSocket 메시지 전송 실패! 사용자: {}", userId, e);
+            }
+        } else {
+            // WARN 레벨: 알림을 보내야 할 사용자의 세션이 없는 경우, 중요한 이벤트 누락 가능성
+            log.warn("메시지를 전송할 수 없음. 세션이 존재하지 않거나 닫혀있음. 사용자: {}", userId);
+        }
+    }
+
+
+    /**
+     * 세션 URI의 쿼리 스트링에서 사용자 ID를 추출합니다.
+     * 예: "/ws/waitqueue?userId=user-1" -> "user-1"
+     *
+     * @param session 클라이언트 세션
+     * @return 추출된 사용자 ID, 없으면 null
+     */
+    private String extractUserId(WebSocketSession session) {
+        // TODO: [보안] 실제 운영 환경에서는 보안을 위해 쿼리 스트링 대신,
+        // WebSocket Handshake 과정에서 인터셉터를 통해 JWT 같은 인증 토큰을 검증하고 사용자 ID를 추출해야 합니다.
+        if (session.getUri() == null || session.getUri().getQuery() == null) {
+            return null;
+        }
+
+        String query = session.getUri().getQuery();
+        for (String param : query.split("&")) {
+            String[] pair = param.split("=");
+            if (pair.length == 2 && "userId".equals(pair[0])) {
+                return pair[1];
+            }
+        }
+        return null;
+    }
+
+    // 테스트와 외부에서 세션을 추가하기 위한 public 메서드
+    public void addSession(String userId, WebSocketSession session) {
+        sessions.put(userId, session);
+    }
+
+    public void sendMessage(WebSocketSession session, TextMessage message) throws IOException {
+        session.sendMessage(message);
+    }
+}

--- a/src/main/java/com/team03/ticketmon/websocket/subscriber/RedisMessageSubscriber.java
+++ b/src/main/java/com/team03/ticketmon/websocket/subscriber/RedisMessageSubscriber.java
@@ -1,0 +1,63 @@
+package com.team03.ticketmon.websocket.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team03.ticketmon.queue.dto.AdmissionEvent;
+import com.team03.ticketmon.websocket.handler.CustomWebSocketHandler;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RTopic;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Redis의 'admission-channel' 토픽을 구독(Subscribe)하는 리스너
+ * 메시지가 발행되면 이를 수신하여 WebSocket을 통해 특정 클라이언트에게 알림을 전달
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisMessageSubscriber {
+
+    private final RedissonClient redissonClient;
+    private final ObjectMapper objectMapper;
+    private final CustomWebSocketHandler webSocketHandler;
+    private static final String ADMISSION_TOPIC = "admission-channel";
+
+    /**
+     * 빈(Bean)이 생성되고 의존성 주입이 완료된 후, 자동으로 Redis 토픽 구독을 시작
+     */
+    @PostConstruct // 빈이 생성된 후 자동으로 이 메서드를 실행
+    public void subscribeToAdmissionTopic() {
+        RTopic topic = redissonClient.getTopic(ADMISSION_TOPIC);
+
+        // 메시지를 수신했을 때 실행될 리스너를 등록.
+        topic.addListener(CharSequence.class, (channel, msg) -> {
+//            log.debug("Redis 채널에서 메시지 수신. 채널: {}, 원본 메시지: {}", channel, msg);
+            log.info("Redis 채널에서 메시지 수신. 채널: {}, 원본 메시지: {}", channel, msg);
+            try {
+                // 1. 수신된 JSON 메시지를 AdmissionEvent 객체로 역직렬화
+                AdmissionEvent event = objectMapper.readValue(msg.toString(), AdmissionEvent.class);
+                log.info("입장 알림 이벤트 수신 완료. 사용자: {}", event.userId());
+
+                // 2. WebSocket 핸들러를 통해 해당 사용자에게 전송할 메시지(Payload)를 구성
+                Map<String, Object> payload = Map.of(
+                        "type", "ADMIT",
+                        "accessKey", event.accessKey()
+                );
+
+                // 3. 구성된 메시지를 실제 클라이언트에게 전송
+                webSocketHandler.sendMessageToUser(event.userId(), payload);
+
+            } catch (IOException e) {
+                // 메시지 파싱 또는 처리 실패는 데이터 형식 문제일 수 있으므로 ERROR 레벨로 기록
+                log.error("수신된 Redis 메시지 처리 중 오류 발생!", e);
+            }
+        });
+
+        log.info("Redis Pub/Sub 구독 시작. 채널: '{}'", ADMISSION_TOPIC);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+app:
+  max-active-users: 5 # 예매 페이지에 동시 진입 가능한 최대 사용자 수
+  access-key-ttl-minutes: 1 # 예매 페이지 접근 키의 유효시간 (단위: 분)
+
 spring:
   application:
     name: ticketmon-go
@@ -5,8 +9,8 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:dev}  # .env 값 우선 사용, 없으면 dev 기본값
     # 🚨 기본값은 'prod'입니다. 로컬 개발 시에만 'dev'로 바꿔주세요.
 
-  autoconfigure:
-    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration  # 임시로 DB 자동 설정 제외 (설정이 없을 경우 에러 방지)
+#  autoconfigure:
+#    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration  # 임시로 DB 자동 설정 제외 (설정이 없을 경우 에러 방지)
     # 실제 DB 사용 시엔 위 라인 제거. 현재는 데이터소스 수동 설정을 의미
 
   jackson:

--- a/src/main/resources/static/queue/index.html
+++ b/src/main/resources/static/queue/index.html
@@ -1,0 +1,86 @@
+<!--resources/static/queue/index.html-->
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Ticketing System Test</title>
+</head>
+<body>
+<h1>대기열 시스템 테스트</h1>
+<input type="text" id="userIdInput" placeholder="사용자 ID 입력 (예: user-1)">
+<button onclick="enterQueue()">대기열 진입</button>
+<hr>
+<h2>상태 로그</h2>
+<div id="log"></div>
+
+<script>
+    const logDiv = document.getElementById('log');
+
+    function log(message) {
+        logDiv.innerHTML += `<p>${new Date().toISOString()}: ${message}</p>`;
+    }
+
+    // 1. 대기열 진입 버튼 클릭 시 실행
+    async function enterQueue() {
+        const userId = document.getElementById('userIdInput').value;
+        if (!userId) {
+            alert('사용자 ID를 입력하세요.');
+            return;
+        }
+        log(`[요청] ${userId}님, 대기열 진입 시도...`);
+
+        try {
+            const response = await fetch('/api/queue/enter', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ userId: userId, concertId: 1 })
+            });
+
+            if (!response.ok) {
+                throw new Error('대기열 진입 실패');
+            }
+
+            const data = await response.json();
+            log(`[응답] ${data.userId}님, 현재 대기 순번은 ${data.rank} 입니다. WebSocket 연결을 시작합니다.`);
+
+            // 2. 응답 성공 시, WebSocket 연결
+            connectWebSocket(data.userId);
+
+        } catch (error) {
+            log(`[에러] ${error.message}`);
+        }
+    }
+
+    // 3. WebSocket 연결 함수
+    function connectWebSocket(userId) {
+        // 실제 운영에서는 wss:// 프로토콜 사용
+        const ws = new WebSocket(`ws://localhost:8080/ws/waitqueue?userId=${userId}`);
+
+        ws.onopen = () => {
+            log(`[WebSocket] 연결 성공! (사용자: ${userId})`);
+        };
+
+        // 4. 서버로부터 메시지 수신
+        ws.onmessage = (event) => {
+            log(`[WebSocket] 메시지 수신: ${event.data}`);
+            const message = JSON.parse(event.data);
+
+            // 5. 입장 메시지 수신 시 알림
+            if (message.type === 'ADMIT') {
+                alert(`입장 시간입니다! AccessKey: ${message.accessKey}`);
+                log(`[성공] 입장 허가! AccessKey: ${message.accessKey}. 이제 예매 페이지로 이동할 수 있습니다.`);
+                ws.close();
+            }
+        };
+
+        ws.onclose = () => {
+            log('[WebSocket] 연결 종료.');
+        };
+
+        ws.onerror = (error) => {
+            log(`[WebSocket] 에러 발생: ${error}`);
+        };
+    }
+</script>
+</body>
+</html>

--- a/src/test/java/com/team03/ticketmon/queue/flow/AdmissionFlowIntegrationTest.java
+++ b/src/test/java/com/team03/ticketmon/queue/flow/AdmissionFlowIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.team03.ticketmon.queue.flow;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.team03.ticketmon.websocket.handler.CustomWebSocketHandler;
+import com.team03.ticketmon.queue.dto.AdmissionEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * 사용자 입장 처리의 전체 흐름(End-to-End)을 검증하는 통합 테스트 클래스.
+ * Redis에 입장 이벤트가 발행(Publish)되었을 때, 해당 이벤트가 구독자(Subscriber)를 통해 처리되어
+ * 최종적으로 WebSocket 핸들러가 특정 사용자에게 메시지를 보내는 과정 전체를 테스트합니다.
+ */
+@ActiveProfiles("test")
+@Testcontainers
+@SpringBootTest
+class AdmissionFlowIntegrationTest {
+
+    @Autowired
+    private RedissonClient redissonClient;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * {@code @MockitoSpyBean:} 실제 Spring Bean(CustomWebSocketHandler)을 가져오되,
+     * 해당 객체의 일부 메서드 동작을 원하는 대로 제어(stubbing)하거나 호출 여부를 검증(verify)할 수 있게 합니다.
+     * 실제 객체의 로직을 대부분 유지하면서 특정 상호작용만 테스트하고 싶을 때 유용합니다.
+     */
+    @MockitoSpyBean
+    private CustomWebSocketHandler customWebSocketHandler;
+
+    @Container
+    public static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", () -> redis.getHost());
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @Test
+    @DisplayName("입장 이벤트가 Redis에 발행되면, WebSocketHandler가 해당 사용자에게 입장 메시지를 전송한다.")
+    void fullAdmissionFlowTest() throws Exception {
+        // given
+        String userId = "user-to-admit";
+        String accessKey = "new-access-key";
+        AdmissionEvent event = new AdmissionEvent(userId, accessKey);
+
+        // 1. 테스트를 위한 가짜 WebSocket 세션을 생성합니다.
+        WebSocketSession mockSession = mock(WebSocketSession.class);
+        // 핸들러 내부 로직(session.isOpen())이 통과되도록 Mock 객체의 행동을 미리 지정(stubbing)합니다.
+        when(mockSession.isOpen()).thenReturn(true);
+        // 생성한 가짜 세션을 실제 핸들러에 등록하여, 'user-to-admit' 사용자가 연결된 것처럼 설정합니다.
+        customWebSocketHandler.addSession(userId, mockSession);
+
+        // 2. 테스트의 트리거(trigger)가 되는 입장 이벤트를 Redis 채널에 직접 발행합니다.
+        String message = objectMapper.writeValueAsString(event);
+        redissonClient.getTopic("admission-channel").publish(message);
+
+        // when & then: 실행 및 결과 검증
+        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
+
+        // Awaitility를 사용해 비동기 작업(메시지 수신 및 처리)이 완료될 때까지 최대 10초간 기다립니다.
+        // 최종적으로 customWebSocketHandler의 sendMessage 메서드가 호출되는지 검증합니다.
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            verify(customWebSocketHandler).sendMessage(eq(mockSession), messageCaptor.capture());
+        });
+
+        // 검증: 핸들러가 전송한 메시지의 내용이 정확한지 확인합니다.
+        TextMessage sentMessage = messageCaptor.getValue();
+        Map<String, Object> sentPayload = objectMapper.readValue(
+                sentMessage.getPayload(),
+                new TypeReference<>() {}
+        );
+
+        assertThat(sentPayload)
+                .containsEntry("type", "ADMIT")
+                .containsEntry("accessKey", accessKey);
+    }
+}

--- a/src/test/java/com/team03/ticketmon/queue/scheduler/CleanupSchedulerTest.java
+++ b/src/test/java/com/team03/ticketmon/queue/scheduler/CleanupSchedulerTest.java
@@ -1,0 +1,76 @@
+package com.team03.ticketmon.queue.scheduler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles("test")
+class CleanupSchedulerTest {
+
+    @Autowired
+    private CleanupScheduler cleanupScheduler;
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Container
+    public static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", () -> redis.getHost());
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @AfterEach
+    void tearDown() {
+        redissonClient.getKeys().flushall();
+    }
+
+    @Test
+    @DisplayName("정리 스케줄러가 실행되면, 만료된 세션을 감지하여 활성 사용자 수를 감소시킨다.")
+    void cleanupExpiredSessions() {
+        // given
+        // 1. 초기 활성 사용자 수를 5로 설정
+        RAtomicLong activeUsersCount = redissonClient.getAtomicLong("active_users_count");
+        activeUsersCount.set(5);
+
+        // 2. active_sessions Set에 테스트 데이터 추가
+        RScoredSortedSet<String> activeSessions = redissonClient.getScoredSortedSet("active_sessions");
+        long now = System.currentTimeMillis();
+        // - 만료된 사용자 2명 (과거 시간)
+        activeSessions.add(now - 10000, "expired-user-1");
+        activeSessions.add(now - 5000, "expired-user-2");
+        // - 아직 유효한 사용자 3명 (미래 시간)
+        activeSessions.add(now + 60000, "active-user-1");
+        activeSessions.add(now + 70000, "active-user-2");
+        activeSessions.add(now + 80000, "active-user-3");
+
+        // when
+        cleanupScheduler.cleanupExpiredSessions();
+
+        // then
+        // 1. 활성 사용자 수가 2명 감소하여 3명이 되었는가?
+        assertThat(activeUsersCount.get()).isEqualTo(3);
+        // 2. active_sessions Set에는 유효한 3명만 남아있는가?
+        assertThat(activeSessions.size()).isEqualTo(3);
+        // 3. 만료된 사용자가 정말로 삭제되었는가?
+        assertThat(activeSessions.contains("expired-user-1")).isFalse();
+    }
+}

--- a/src/test/java/com/team03/ticketmon/queue/scheduler/WaitingQueueSchedulerIntegrationTest.java
+++ b/src/test/java/com/team03/ticketmon/queue/scheduler/WaitingQueueSchedulerIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.team03.ticketmon.queue.scheduler;
+
+import com.team03.ticketmon.queue.service.WaitingQueueService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * WaitingQueueScheduler의 핵심 로직이 올바르게 동작하는지 검증하는 통합 테스트.
+ * 실제 스케줄링 시간(fixedDelay)에 의존하지 않고, scheduler.execute() 메서드를 직접 호출하여
+ * 실행 전후의 Redis 상태 변화를 확인합니다.
+ */
+@ActiveProfiles("test")
+@Testcontainers
+@SpringBootTest
+class WaitingQueueSchedulerIntegrationTest {
+
+    @Autowired
+    private WaitingQueueScheduler waitingQueueScheduler;
+    @Autowired
+    private WaitingQueueService waitingQueueService;
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Container
+    public static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", () -> redis.getHost());
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    /**
+     * 각 테스트 실행 후, Redis의 모든 데이터를 삭제하여 테스트 간의 독립성을 보장합니다.
+     */
+    @AfterEach
+    void tearDown() {
+        // 각 테스트가 서로에게 영향을 주지 않도록, 테스트 실행 후 Redis 데이터를 모두 삭제합니다.
+        redissonClient.getKeys().flushall();
+    }
+
+    @Test
+    @DisplayName("스케줄러가 실행되면, 대기열의 사용자를 입장시키고, AccessKey를 발급하며, 활성 사용자 수를 증가시킨다.")
+    void execute_shouldAdmitUsers_and_updateStateInRedis() throws InterruptedException {
+        // given: 3명의 사용자가 대기열에 있고, 2개의 빈 자리가 있는 상황
+        long concertId = 1L;
+        waitingQueueService.apply(concertId, "user-1");
+        waitingQueueService.apply(concertId, "user-2");
+        waitingQueueService.apply(concertId, "user-3");
+
+        RAtomicLong activeUsersCount = redissonClient.getAtomicLong("active_users_count");
+        activeUsersCount.set(498); // 최대 500명 중 498명 -> 2자리 남음
+
+        // when: 스케줄러 로직 실행
+        waitingQueueScheduler.execute();
+
+        // then: 로직 실행 후 Redis의 상태가 올바르게 변경되었는지 검증
+        // 비동기(Pub/Sub) 처리 시간을 고려하여 Awaitility로 최대 5초 대기
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            // 1. 활성 사용자 수가 2명 증가하여 500명이 되었는가?
+            assertThat(redissonClient.getAtomicLong("active_users_count").get()).isEqualTo(500L);
+
+            // 2. 대기열에는 1명(user-3)만 남아있는가?
+            assertThat(waitingQueueService.getWaitingCount(concertId)).isEqualTo(1L);
+
+            // 3. 입장 처리된 사용자(user-1, user-2)에게 AccessKey가 발급되었는가?
+            RBucket<String> accessKey1 = redissonClient.getBucket("accesskey:user-1");
+            RBucket<String> accessKey2 = redissonClient.getBucket("accesskey:user-2");
+            assertThat(accessKey1.isExists()).isTrue();
+            assertThat(accessKey2.isExists()).isTrue();
+
+            // 4. 발급된 AccessKey에 유효시간(TTL)이 올바르게 설정되었는가? (10분 이하)
+            assertThat(accessKey1.remainTimeToLive()).isPositive().isLessThanOrEqualTo(TimeUnit.MINUTES.toMillis(10));
+        });
+    }
+
+    @Test
+    @DisplayName("활성 사용자 수가 최대치 이상일 때, 스케줄러는 아무 작업도 하지 않아야 한다.")
+    void execute_shouldDoNothing_whenNoSlotIsAvailable() throws InterruptedException {
+        // given: 대기열에 사용자가 있지만, 활성 사용자 수가 꽉 찬 상황
+        long concertId = 1L;
+        waitingQueueService.apply(concertId, "user-1");
+
+        RAtomicLong activeUsersCount = redissonClient.getAtomicLong("active_users_count");
+        activeUsersCount.set(500); // 빈자리 없음
+
+        // when: 스케줄러 로직 실행
+        waitingQueueScheduler.execute();
+
+        // then: Redis의 상태에 아무 변화가 없어야 함
+        // 1. 활성 사용자 수는 그대로 500명이어야 한다.
+        assertThat(activeUsersCount.get()).isEqualTo(500L);
+        // 2. 대기열 인원도 그대로 1명이어야 한다.
+        assertThat(waitingQueueService.getWaitingCount(concertId)).isEqualTo(1L);
+        // 3. 대기중인 사용자에게 AccessKey가 발급되지 않았어야 한다.
+        assertThat(redissonClient.getBucket("accesskey:user-1").isExists()).isFalse();
+    }
+}

--- a/src/test/java/com/team03/ticketmon/queue/service/NotificationServiceTest.java
+++ b/src/test/java/com/team03/ticketmon/queue/service/NotificationServiceTest.java
@@ -1,0 +1,91 @@
+package com.team03.ticketmon.queue.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team03.ticketmon.queue.dto.AdmissionEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RTopic;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * NotificationService가 Redis Pub/Sub으로 메시지를 올바르게 발행(Publish)하는지 검증하는 테스트 클래스.
+ */
+@ActiveProfiles("test")
+@Testcontainers
+@SpringBootTest
+class NotificationServiceTest {
+
+    @Autowired
+    private NotificationService notificationService;
+    @Autowired
+    private RedissonClient redissonClient;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * @Container: 이 필드가 Testcontainer 임을 나타냅니다.
+     * 테스트 클래스가 실행될 때 Docker를 이용해 Redis 컨테이너를 자동으로 실행시켜줍니다.
+     */
+    @Container
+    public static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    /**
+     * @DynamicPropertySource: Testcontainer가 실행된 후, 동적으로 할당된 IP와 포트 정보를
+     * Spring의 Environment 속성으로 주입해주는 역할을 합니다.
+     * 이를 통해 애플리케이션이 테스트용 임시 Redis 컨테이너에 연결될 수 있습니다.
+     */
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", () -> redis.getHost());
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @Test
+    @DisplayName("입장 알림을 보내면, Redis Pub/Sub 토픽으로 AdmissionEvent 메시지가 발행된다.")
+    void sendAdmissionNotification() throws InterruptedException, IOException {
+        // given: 테스트용 데이터와 비동기 메시지 수신을 위한 환경 설정
+        String userId = "user-test";
+        String accessKey = "key-test";
+
+        // CountDownLatch: 비동기 작업(메시지 수신)이 완료될 때까지 메인 스레드를 기다리게 하는 도구
+        CountDownLatch latch = new CountDownLatch(1);
+        // AtomicReference: 다른 스레드(리스너)에서 받은 메시지를 메인 스레드에서 안전하게 참조하기 위한 변수
+        AtomicReference<String> receivedMessage = new AtomicReference<>();
+
+        // 테스트용 임시 구독자(Subscriber)를 생성하여 "admission-channel"을 구독
+        RTopic topic = redissonClient.getTopic("admission-channel");
+        topic.addListener(CharSequence.class, (channel, msg) -> {
+            receivedMessage.set(msg.toString()); // 메시지 수신 시, AtomicReference에 저장
+            latch.countDown();                   // Latch의 카운트를 감소시켜 대기 중인 스레드를 깨움
+        });
+
+        // when: 테스트 대상 메서드 호출 (메시지 발행)
+        notificationService.sendAdmissionNotification(userId, accessKey);
+
+        // then: 발행된 메시지가 구독자에게 성공적으로 도달했는지 검증
+        // Latch가 0이 될 때까지 최대 5초간 대기. 시간 내에 메시지를 받으면 true 반환
+        boolean isMessageReceived = latch.await(5, TimeUnit.SECONDS);
+        assertThat(isMessageReceived).isTrue(); // 시간 내에 메시지를 받았는지 확인
+
+        // 받은 JSON 메시지를 객체로 변환하여 내용이 정확한지 검증
+        AdmissionEvent event = objectMapper.readValue(receivedMessage.get(), AdmissionEvent.class);
+        assertThat(event.userId()).isEqualTo(userId);
+        assertThat(event.accessKey()).isEqualTo(accessKey);
+    }
+}

--- a/src/test/java/com/team03/ticketmon/queue/service/WaitingQueueServiceTest.java
+++ b/src/test/java/com/team03/ticketmon/queue/service/WaitingQueueServiceTest.java
@@ -1,0 +1,133 @@
+package com.team03.ticketmon.queue.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * WaitingQueueService의 핵심 기능(대기열 추가, 조회, 추출)을 검증하는 테스트 클래스.
+ * Redis의 Sorted Set을 사용하는 로직이 정확히 동작하는지 확인합니다.
+ */
+@ActiveProfiles("test") // 테스트용 프로필 사용
+@Testcontainers
+@SpringBootTest
+class WaitingQueueServiceTest {
+
+    @Autowired
+    private WaitingQueueService waitingQueueService;
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Container
+    public static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+
+    /**
+     * @DynamicPropertySource는 Testcontainers의 컨테이너가 실행된 후,
+     * 스프링의 ApplicationContext가 로드되기 전에 호출됩니다. (없으면 컨테이너 실행전 로드라 오류)
+     * 이 메서드를 통해 동적으로 생성된 컨테이너의 주소와 포트를
+     * 스프링 설정(Environment)에 주입할 수 있습니다.
+     */
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", () -> redis.getHost());
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    /**
+     * 각 테스트가 실행되기 전, Redis 데이터를 모두 삭제하여 테스트 간의 완벽한 독립성을 보장합니다.
+     * (@AfterEach 대신 @BeforeEach를 사용하면, 테스트 실패 시에도 다음 테스트는 깨끗한 환경에서 시작할 수 있습니다.)
+     */
+    @BeforeEach
+    void setUp() {
+        // 현재 Redis 데이터베이스의 모든 키를 삭제합니다.
+        redissonClient.getKeys().flushdb();
+    }
+
+    @Test
+    @DisplayName("여러 사용자가 순차적으로 진입하면 각자의 순번을 정확히 반환한다.")
+    void applyAndGetRank_multipleUsers() {
+        // given, when: 3명의 사용자가 순서대로 대기열에 진입
+        Long rank1 = waitingQueueService.apply(1L, "user-1");
+        Long rank2 = waitingQueueService.apply(1L, "user-2");
+        Long rank3 = waitingQueueService.apply(1L, "user-3");
+
+        // then: 각자 1, 2, 3등의 순번을 부여받는다.
+        assertThat(rank1).isEqualTo(1L);
+        assertThat(rank2).isEqualTo(2L);
+        assertThat(rank3).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("이미 대기열에 있는 사용자가 다시 진입을 시도해도 순번은 변하지 않는다 (멱등성).")
+    void applyAndGetRank_idempotency() throws InterruptedException {
+        // given: user-1이 먼저 진입하고, 잠시 후 user-2가 진입
+        Long initialRankOfUser1 = waitingQueueService.apply(1L, "user-1");
+        Thread.sleep(10); // 점수(timestamp)를 다르게 하기 위한 지연
+        waitingQueueService.apply(1L, "user-2");
+
+        // when: user-1이 다시 진입을 시도
+        Long updatedRankOfUser1 = waitingQueueService.apply(1L, "user-1");
+
+        // then: user-1의 순번은 처음 부여받은 1등에서 변하지 않는다.
+        assertThat(initialRankOfUser1).isEqualTo(1L);
+        assertThat(updatedRankOfUser1).isEqualTo(initialRankOfUser1);
+    }
+
+    @Test
+    @DisplayName("서로 다른 콘서트의 대기열은 서로 영향을 주지 않는다.")
+    void apply_shouldManageQueuesSeparately_forDifferentConcerts() {
+        // given: 두 개의 다른 콘서트 ID
+        long concertIdA = 1L;
+        long concertIdB = 2L;
+
+        // when: 각 콘서트에 사용자들이 신청
+        Long rankA1 = waitingQueueService.apply(concertIdA, "user-1");
+        Long rankB1 = waitingQueueService.apply(concertIdB, "user-A");
+        Long rankA2 = waitingQueueService.apply(concertIdA, "user-2");
+
+        // then: 각 콘서트 대기열은 독립적으로 순번을 계산한다.
+        assertThat(rankA1).isEqualTo(1L);
+        assertThat(rankB1).isEqualTo(1L);
+        assertThat(rankA2).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("대기열에서 N명을 추출(poll)하면, 가장 오래 기다린 N명이 순서대로 반환되고 대기열에서 제거된다.")
+    void poll() throws InterruptedException {
+        // given: 3명의 사용자가 순서대로 대기열에 진입
+        long concertId = 1L;
+        waitingQueueService.apply(concertId, "user-1");
+        Thread.sleep(10);
+        waitingQueueService.apply(concertId, "user-2");
+        Thread.sleep(10);
+        waitingQueueService.apply(concertId, "user-3");
+
+        // when: 가장 오래 기다린 2명을 추출
+        List<String> polledUsers = waitingQueueService.poll(concertId, 2);
+
+        // then:
+        // 1. 요청한 2명이 반환되었는가?
+        assertThat(polledUsers).hasSize(2);
+        // 2. 가장 먼저 들어온 순서("user-1", "user-2")대로 반환되었는가?
+        assertThat(polledUsers).containsExactly("user-1", "user-2");
+        // 3. 대기열에 남은 인원은 1명인가?
+        assertThat(waitingQueueService.getWaitingCount(concertId)).isEqualTo(1L);
+        // 4. 대기열에 남은 user-3의 순번은 1등이 되었는가?
+        assertThat(waitingQueueService.apply(concertId, "user-3")).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
### **1. 작업 내용**
대규모 트래픽 발생 시 안정적인 서비스 처리를 위해 Redis 기반의 대기열 시스템의 핵심 기능을 구현했습니다.

-   [x] Redis Sorted Set을 이용한 대기열 서비스(`WaitingQueueService`) 구현
-   [x] 대기열 진입을 위한 동기 API (`POST /api/queue/enter`) 엔드포인트 구현
-   [x] 실시간 입장 알림을 위한 WebSocket 및 Redis Pub/Sub 연동 설정
-   [x] 주기적으로 대기자를 입장시키는 스케줄러(`WaitingQueueScheduler`) 구현
-   [x] Testcontainers를 이용한 대기열 핵심 로직 통합 테스트 작성

![image](https://github.com/user-attachments/assets/6cdacae7-97b4-41e2-95bb-c506f61015f5)

![image](https://github.com/user-attachments/assets/d40862fa-3187-4e53-90b2-65571d3d0296)

![image](https://github.com/user-attachments/assets/1dfabf0e-7b4a-48d1-8eb2-88b90197d194)

### **2. 주요 변경사항**
**새로 추가된 파일:**
-   `queue/controller/WaitingQueueController.java` – 대기열 진입을 위한 API 엔드포인트
-   `queue/service/WaitingQueueService.java` – Redis Sorted Set을 활용한 대기열 핵심 비즈니스 로직
-   `queue/service/NotificationService.java` – Redis Pub/Sub으로 입장 알림을 발행하는 서비스
-   `queue/scheduler/WaitingQueueScheduler.java` – 주기적으로 대기열의 사용자를 입장시키는 핵심 스케줄러
-   `queue/scheduler/CleanupScheduler.java` – 만료된 활성 세션을 정리하는 보조 스케줄러
-   `websocket/handler/CustomWebSocketHandler.java` – 실시간 알림 전송을 위한 WebSocket 세션 관리 핸들러
-   `websocket/subscriber/RedisMessageSubscriber.java` – Pub/Sub 메시지를 구독하여 WebSocket으로 전달하는 리스너
-   `config/WebSocketConfig.java` – WebSocket 핸들러를 등록하고 경로를 설정
-   `queue/dto/AdmissionEvent.java` / `EnterRequest.java` – 기능에 사용되는 데이터 전송 객체 (DTO)
-   `resources/static/queue/index.html` – 대기열 진입 및 WebSocket 알림 수신을 위한 테스트용 클라이언트

**수정된 파일:**
-   `config/RedissonConfig.java` – 로컬(redis://) 및 SSL(rediss://) 연결을 모두 지원하도록 URL 생성 로직 수정
-   `build.gradle` – Redisson, Testcontainers 등 대기열 기능에 필요한 의존성 추가
-   `application.yml` – 대기열 관련 설정값(`max-active-users` 등) 추가

### **3. 향후 개선 및 고려사항**
이번 구현은 대기열 시스템의 핵심 골격을 완성하는 데 중점을 두었으며, 안정적이고 확장성 있는 서비스 운영을 위해 아래와 같은 사항들을 추가적으로 고려하고 개선해 나가야 합니다.

---
#### **기능 고도화 및 UX**

-   **WebSocket 연결 실패 시 Fallback**: 사용자의 네트워크 환경에 따라 WebSocket 연결이 불안정할 수 있습니다. 연결 실패 시, 일정 시간 동안 주기적으로 서버 상태를 조회하는 **HTTP Polling 방식으로 자동 전환**하는 Fallback 메커니즘을 도입하여 서비스 연속성을 높일 수 있습니다.
-   **콘서트별 동적 대기열 운영**: 현재는 단일 콘서트(ID `1L`)를 가정하고 있습니다. 향후 여러 콘서트가 동시에 진행될 경우, 각 콘서트의 특성(서버 사양, 예상 트래픽)에 맞춰 `max_active_users` 등의 정책을 동적으로 관리하고 적용하는 기능이 필요합니다.

---
#### **안정성 및 성능**

-   **기존 전역 예외 처리 연동**: 현재 프로젝트에는 `GlobalExceptionHandler`와 `ErrorCode` 등 표준 예외 처리 기반이 이미 구현되어 있습니다. 이번에 추가된 대기열 관련 서비스 로직에서 발생하는 예외 상황들을(예: `SEAT_ALREADY_TAKEN`, `LOCK_ACQUISITION_FAILED` 등) `throw new BusinessException(ErrorCode.해당_에러)` 형태로 변경하여, 기존 예외 처리 흐름에 맞게 통합해야 합니다.
-   **인증 방식 개선**: 현재 API는 `userId`를 Request Body로 받지만, 이는 보안에 취약합니다. 추후 Spring Security와 JWT를 도입하여 인증된 사용자 정보(`@AuthenticationPrincipal`)를 사용하도록 수정이 필요합니다.
-   **Redis 스케일 아웃**: 극단적인 트래픽 증가 시 Redis의 부하 분산을 위해 단일 서버(`useSingleServer`) 구성에서 **Redis Cluster 또는 Sentinel을 활용한 고가용성 구성**으로의 전환을 고려해야 합니다.

---
#### **운영 및 모니터링**

-   **스케줄러 활성화 및 설정**: 구현된 스케줄러들을 동작시키려면, 메인 애플리케이션(`TicketmonGoApplication.java`)에 `@EnableScheduling` 어노테이션을 추가해야 합니다. 또한 현재 10초로 고정된 스케줄러 실행 주기를 트래픽 상황에 따라 유연하게 조절할 수 있도록 외부 설정으로 분리하는 것을 고려해야 합니다.
-   **핵심 지표 모니터링**: **대기열 길이, 분당 입장 처리 수, 활성 사용자 수, 좌석 선점 실패율** 등 시스템 상태를 파악할 수 있는 핵심 지표들을 Prometheus, Grafana 등의 모니터링 도구로 시각화하고 임계치 알람을 설정해야 합니다.
-   **구조화된 로깅**: 현재 `Slf4j`를 사용한 로그를 더 체계적으로 관리하기 위해, JSON 포맷 등으로 **구조화된 로그(Structured Logging)**를 도입해야 합니다. 이를 통해 Logstash나 CloudWatch Logs Insight 등에서 로그를 검색하고 분석하기 용이해집니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 대기열 시스템의 REST API 및 WebSocket 기반 실시간 알림 기능이 추가되었습니다.
    - 대기열 입장, 사용자 순위 확인, 입장 승인 알림 등 주요 대기열 관리 기능이 제공됩니다.
    - 대기열 테스트용 웹 페이지가 추가되어 직접 기능을 확인할 수 있습니다.
- **버그 수정**
    - Redis 연결 설정이 개선되어 인증 정보 누락 시에도 안정적으로 동작합니다.
- **문서화**
    - 애플리케이션 설정 파일에 주요 환경 변수 및 주석이 보강되었습니다.
- **테스트**
    - 대기열, 스케줄러, 알림 서비스 등 신규 기능에 대한 통합 및 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->