### PR TITLE
[대기열] 분산 환경 스케줄러 안정성 확보 및 설정 코드 개선

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/config/RedissonConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/RedissonConfig.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.redisson.config.SingleServerConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -49,7 +50,7 @@ public class RedissonConfig {
         log.info("Redisson Client를 생성합니다. Address: {}", redisUrl);
 
         // 단일 서버 모드 설정
-        config.useSingleServer()
+        SingleServerConfig serverConfig = config.useSingleServer()
                 .setAddress(redisUrl)
                 .setConnectionMinimumIdleSize(1)    // 최소 유휴 연결 수
                 .setConnectionPoolSize(10)          // 연결 풀 크기
@@ -58,11 +59,12 @@ public class RedissonConfig {
                 .setTimeout(3000);                  // 타임아웃 (ms)
 
         if (StringUtils.hasText(redisUsername)) {
-            config.useSingleServer().setUsername(redisUsername);
+            serverConfig.setUsername(redisUsername);
         }
         if (StringUtils.hasText(redisPassword)) {
-            config.useSingleServer().setPassword(redisPassword);
+            serverConfig.setPassword(redisPassword);
         }
+
         return Redisson.create(config);
     }
 }

--- a/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
+++ b/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
@@ -4,10 +4,7 @@ import com.team03.ticketmon.queue.service.NotificationService;
 import com.team03.ticketmon.queue.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RAtomicLong;
-import org.redisson.api.RBucket;
-import org.redisson.api.RScoredSortedSet;
-import org.redisson.api.RedissonClient;
+import org.redisson.api.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -15,17 +12,18 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
- * 주기적으로 대기열을 확인하여 입장 가능 인원을 처리하는 스케줄러입니다.
- * 이 스케줄러는 시스템의 처리량을 조절하는 핵심적인 역할을 담당합니다.
+ * 주기적으로 대기열을 확인하여 입장 가능 인원을 처리하는 스케줄러.
+ * 이 스케줄러는 시스템의 처리량을 조절하는 핵심적인 역할을 담당하며,
+ * 분산 환경에서도 단 하나의 인스턴스만 실행되도록 분산 락(Distributed Lock)을 사용.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class WaitingQueueScheduler {
 
-    private static final String ACTIVE_SESSIONS_KEY = "active_sessions";
     private final WaitingQueueService waitingQueueService;
     private final RedissonClient redissonClient;
     private final NotificationService notificationService;
@@ -35,81 +33,118 @@ public class WaitingQueueScheduler {
     @Value("${app.access-key-ttl-minutes}")
     private long accessKeyTtlMinutes; // 발급된 입장 허가 키의 유효 시간 (분)
 
-    private static final String ACCESS_KEY_PREFIX = "accesskey:"; // 사용자별 입장 허가 키 (String)
-    private static final String ACTIVE_USERS_COUNT_KEY = "active_users_count"; // 현재 활성 사용자 수 (AtomicLong)
+    // --- Redis 키 정의 ---
+    /** 분산 락을 위한 키. 이 락을 획득한 인스턴스만이 스케줄러 로직을 실행. */
+    private static final String ADMISSION_LOCK_KEY = "lock:admissionScheduler";
+    /** 현재 활성 세션 정보를 저장하는 Sorted Set 키. Score는 세션 만료 시간(timestamp). */
+    private static final String ACTIVE_SESSIONS_KEY = "active_sessions";
+    /** 사용자별 입장 허가 키(Access Key)를 저장하는 String 키의 접두사. (예: accesskey:user-123) */
+    private static final String ACCESS_KEY_PREFIX = "accesskey:";
+    /** 현재 시스템의 총 활성 사용자 수를 저장하는 AtomicLong 키. */
+    private static final String ACTIVE_USERS_COUNT_KEY = "active_users_count";
 
     // TODO: 현재는 단일 콘서트를 가정하여 ID를 1L로 고정했지만, 향후 여러 콘서트를 지원하려면 이 로직을 동적으로 변경해야함
     private static final long CONCERT_ID = 1L;
 
 
     /**
-     * 10초마다 주기적으로 실행되어 대기열을 처리합니다.
-     * fixedDelay는 이전 작업이 끝난 후 10초를 기다리는 것을 의미합니다.
+     * 10초마다 주기적으로 실행되어 대기열을 처리.
+     * fixedDelay는 이전 작업이 성공적으로 끝난 후 10초를 기다리는 것을 의미.
+     * 분산 락을 사용하여 여러 인스턴스 중 하나만 이 메서드를 실행하도록 보장.
      */
     @Scheduled(fixedDelay = 10000)
     public void execute() {
-        log.info("===== 대기열 스케줄러 실행 시작 =====");
 
-        // 현재 시스템의 활성 사용자 수를 Redis에서 조회
-        RAtomicLong activeUsersCount = redissonClient.getAtomicLong(ACTIVE_USERS_COUNT_KEY);
-        long currentActiveUsers = activeUsersCount.get();
+        // 분산 락 획득 시도
+        RLock lock = redissonClient.getLock(ADMISSION_LOCK_KEY);
+        try {
+            // [분산 락 획득 시도]
+            // waitTime(0): 락을 기다리지 않고 즉시 획득을 시도. (Fail-Fast)
+            // leaseTime(10): 락을 획득하면 10초간 유지. 만약 이 스레드가 비정상 종료되어도 10초 후 락이 자동 해제되어 다른 인스턴스가 이어서 작업. (데드락 방지)
+            boolean isLocked = lock.tryLock(0, 10, TimeUnit.SECONDS);
 
-        // 입장 가능한 빈자리(slot)를 계산
-        long availableSlots = maxActiveUsers - currentActiveUsers;
+            // 락 획득에 실패하면, 다른 인스턴스가 이미 작업을 수행 중이라는 의미이므로 현재 작업을 종료
+            if (!isLocked) {
+                log.info("다른 인스턴스에서 스케줄러가 실행 중이므로, 현재 스케줄러는 건너뜁니다.");
+                return;
+            }
 
-//        log.debug("활성 사용자 현황: {} / {} (빈자리: {})", currentActiveUsers, maxActiveUsers, availableSlots);
-        log.info("활성 사용자 현황: {} / {} (빈자리: {})", currentActiveUsers, maxActiveUsers, availableSlots);
+            log.info("===== 대기열 스케줄러 실행 시작 =====");
 
-        if (availableSlots <= 0) {
-            log.info("===== 입장 가능한 자리가 없습니다. 스케줄러 작업을 종료 =====");
-            return;
+            // 현재 시스템의 활성 사용자 수를 Redis에서 조회
+            RAtomicLong activeUsersCount = redissonClient.getAtomicLong(ACTIVE_USERS_COUNT_KEY);
+            long currentActiveUsers = activeUsersCount.get();
+
+            // 시스템 최대 수용 인원과 현재 활성 인원을 비교하여, 입장 가능한 빈자리(slot)를 계산.
+            long availableSlots = maxActiveUsers - currentActiveUsers;
+
+
+            //log.debug("활성 사용자 현황: {} / {} (빈자리: {})", currentActiveUsers, maxActiveUsers, availableSlots);
+            log.info("활성 사용자 현황: {} / {} (빈자리: {})", currentActiveUsers, maxActiveUsers, availableSlots);
+
+            if (availableSlots <= 0) {
+                log.info("===== 입장 가능한 자리가 없습니다. 스케줄러 작업을 종료 =====");
+                return;
+            }
+
+            // WaitingQueueService를 통해 빈자리 수만큼 사용자를 원자적으로 추출.
+            List<String> admittedUsers = waitingQueueService.poll(CONCERT_ID, (int) availableSlots);
+
+            if (admittedUsers.isEmpty()) {
+                log.info("===== 새로 입장할 대기 인원이 없습니다. 스케줄러 작업을 종료 =====");
+                return;
+            }
+
+            // 추출된 사용자들에게 입장을 허가하는 후속 작업을 수행
+            grantAccessToUsers(admittedUsers);
+
+            log.info("===== 대기열 스케줄러 실행 종료 =====");
+
+        } catch (InterruptedException e) {
+            // 스레드가 중단 신호를 받으면, 현재 스레드의 중단 상태를 다시 설정하여 상위 코드가 인지할 수 있도록 함.
+            Thread.currentThread().interrupt();
+            log.error("분산 락을 획득하는 동안 인터럽트 발생", e);
+        } finally {
+            // 현재 스레드가 락을 점유하고 있는 경우에만 해제를 시도하여, 다른 스레드가 획득한 락을 해제하는 실수를 방지.
+            if  (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
         }
-
-
-        // 대기열에서 빈자리 수만큼 사용자를 추출
-        List<String> admittedUsers = waitingQueueService.poll(CONCERT_ID, (int) availableSlots);
-
-        if (admittedUsers.isEmpty()) {
-            log.info("===== 새로 입장할 대기 인원이 없습니다. 스케줄러 작업을 종료 =====");
-            return;
-        }
-
-        // 추출된 사용자들에게 입장을 허가
-        grantAccessToUsers(admittedUsers);
-
-        log.info("===== 대기열 스케줄러 실행 종료 =====");
     }
 
     /**
-     * 입장 허가된 사용자들에게 고유 키를 발급하고, 알림을 전송한 후, 활성 사용자 수를 업데이트합니다.
+     * 입장 허가된 사용자들에게 고유 키를 발급하고, 알림을 전송한 후, 활성 사용자 관련 상태를 업데이트.
+     * 이 모든 과정은 하나의 트랜잭션처럼 동작해야 함. (현재는 개별 연산으로 구성)
      *
      * @param admittedUsers 입장 허가된 사용자 ID 리스트
      */
     private void grantAccessToUsers(List<String> admittedUsers) {
         log.info("{}명의 신규 사용자 입장 처리 시작: {}", admittedUsers.size(), admittedUsers);
 
+        // 모든 신규 입장자에게 동일한 만료 시간을 적용하기 위해 현재 시간을 기준으로 만료 타임스탬프를 계산.
         RScoredSortedSet<String> activeSessions = redissonClient.getScoredSortedSet(ACTIVE_SESSIONS_KEY);
         long expiryTimestamp = System.currentTimeMillis() + accessKeyTtlMinutes * 60 * 1000;
 
-
         for (String userId : admittedUsers) {
-            // 1. 사용자별로 예측 불가능한 고유 AccessKey를 발급
+            // 1. 사용자별로 예측 불가능한 고유 AccessKey를 발급하여, 다른 사용자가 키를 추측하여 부정 사용하는 것을 방지.
             String accessKey = UUID.randomUUID().toString();
             RBucket<String> accessKeyBucket = redissonClient.getBucket(ACCESS_KEY_PREFIX + userId);
 
-            // 2. Redis에 AccessKey를 TTL(Time-To-Live)과 함께 저장하여 일정 시간 후 자동 만료되도록
+            // 2. Redis에 AccessKey를 TTL(Time-To-Live)과 함께 저장. 사용자가 이 키를 사용하여 실제 서비스에 접근하면, 서비스는 이 키의 유효성을 검증.
             accessKeyBucket.set(accessKey, Duration.ofMinutes(accessKeyTtlMinutes));
-//            log.debug("사용자 '{}'에게 접근 키 발급 및 저장 완료 (유효 시간: {}분)", userId, accessKeyTtlMinutes);
+            //log.debug("사용자 '{}'에게 접근 키 발급 및 저장 완료 (유효 시간: {}분)", userId, accessKeyTtlMinutes);
             log.info("사용자 '{}'에게 접근 키 발급 및 저장 완료 (유효 시간: {}분)", userId, accessKeyTtlMinutes);
 
-            // 3. 만료 시간을 점수로 하여 active_sessions Set에 추가
+            // 3. 만료 시간을 점수(score)로 하여 'active_sessions' Set에 추가.
+            //    이는 나중에 CleanupScheduler가 만료된 세션을 효율적으로 찾아 정리하는 데 사용.
             activeSessions.add(expiryTimestamp, userId);
 
             // 4. Redis Pub/Sub을 통해 해당 사용자에게 입장하라는 알림을 발행
             notificationService.sendAdmissionNotification(userId, accessKey);
         }
 
-        // 4. 입장시킨 사용자 수만큼 활성 사용자 수를 원자적으로 증가시킵니다.
+        // 5. 입장시킨 사용자 수만큼 활성 사용자 수 원자적으로 증가.
+        //    루프 안에서 1씩 여러 번 증가시키는 것보다, 루프 종료 후 한 번에 더하는 것이 Redis와의 통신 횟수를 줄여 더 효율적.
         long totalActiveUsers = redissonClient.getAtomicLong(ACTIVE_USERS_COUNT_KEY).addAndGet(admittedUsers.size());
         log.info("{}명 입장 완료. 현재 총 활성 사용자 수: {}", admittedUsers.size(), totalActiveUsers);
     }

--- a/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
+++ b/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
@@ -59,9 +59,9 @@ public class WaitingQueueScheduler {
         RLock lock = redissonClient.getLock(ADMISSION_LOCK_KEY);
         try {
             // [분산 락 획득 시도]
-            // waitTime(0): 락을 기다리지 않고 즉시 획득을 시도. (Fail-Fast)
-            // leaseTime(10): 락을 획득하면 10초간 유지. 만약 이 스레드가 비정상 종료되어도 10초 후 락이 자동 해제되어 다른 인스턴스가 이어서 작업. (데드락 방지)
-            boolean isLocked = lock.tryLock(0, 10, TimeUnit.SECONDS);
+            // waitTime(0): waitTime을 0으로 두어, 락 획득에 실패하면 즉시 리턴하는 비대기 모드는 유지
+            // leaseTime(-1): 워치독(락 자동 갱신) 기능을 활성화. 락을 획득하면 기본 30초의 TTL이 설정되고, 작업이 끝나기 전까지 워치독이 락을 계속 갱신
+            boolean isLocked = lock.tryLock(0, -1, TimeUnit.SECONDS);
 
             // 락 획득에 실패하면, 다른 인스턴스가 이미 작업을 수행 중이라는 의미이므로 현재 작업을 종료
             if (!isLocked) {


### PR DESCRIPTION
### 1. 작업 개요

본 PR은 분산 환경에서 발생할 수 있는 스케줄러의 중복 실행 문제를 해결하여 데이터 정합성을 보장하고, Redisson 설정 코드의 효율성을 개선하여 시스템의 전반적인 안정성과 코드 품질을 향상시키는 것을 목표로 합니다.

### 2. 주요 작업 내용

- [x] **WaitingQueueScheduler에 분산 락 적용 및 안정성 강화**: 
  - 여러 인스턴스 환경에서 스케줄러가 오직 하나의 인스턴스에서만 실행되도록 보장하여, 사용자 중복 입장과 같은 심각한 레이스 컨디션을 원천 차단했습니다.
  - **Redisson의 워치독(Watchdog) 메커니즘을 적용**하여 작업 시간 변동에도 락이 안전하게 유지되도록 수정했습니다.
- [x] **RedissonConfig 설정 코드 리팩토링**: `SingleServerConfig` 인스턴스를 한 번만 생성하여 재사용하도록 코드를 개선함으로써, 불필요한 객체 생성을 방지하고 코드의 가독성과 효율성을 높였습니다.

### 3. 주요 변경사항

**🛠 수정된 파일:**
- `queue/scheduler/WaitingQueueScheduler.java`: 분산 락(`RLock`) 적용 및 워치독 활성화 로직 수정
- `_global/config/RedissonConfig.java`: `SingleServerConfig` 초기화 로직 리팩토링

**❌ 삭제/추가된 파일:**
- 없음

### 4. 관련 이슈
- 해당 없음

### 5. 추가 정보 (리뷰어를 위한 가이드)

#### **1. WaitingQueueScheduler 분산 락 적용 (핵심 변경 사항)**

- **문제점:**
  기존 스케줄러는 별도의 동기화 장치 없이, 배포된 모든 인스턴스에서 독립적으로 실행되었습니다. 이는 `N`개의 인스턴스가 동시에 실행되어 **`N * (입장 인원)` 만큼의 사용자가 중복 입장**하는 심각한 데이터 정합성 문제를 야기할 수 있었습니다.

- **해결 방안:**
  Redisson의 분산 락 (`RLock`)을 도입하여 이 문제를 해결했습니다.
  - 스케줄러 실행 직전에 `lock.tryLock()`을 호출하여 락 획득을 시도합니다.
  - `waitTime=0`으로 설정하여, 락 획득에 실패할 경우(다른 인스턴스가 이미 실행 중인 경우) 대기 없이 즉시 작업을 건너뛰도록 하여 리소스를 낭비하지 않습니다.
- **(개선)** 기존의 고정된 `leaseTime` 방식은 작업 시간이 길어질 경우 락이 조기 만료되어 경쟁 조건이 재발하고, `unlock` 시 예외를 발생시키는 위험이 있었습니다.
- **(개선)** 이를 해결하기 위해 `leaseTime`을 `-1`로 설정하여 **Redisson의 '워치독' 기능을 활성화**했습니다. 워치독은 락을 소유한 스레드가 살아있는 동안 락의 만료 시간을 자동으로 계속 연장해주므로, **작업 시간 변동과 관계없이 락을 안전하게 유지하고 데드락을 방지**합니다.

#### **2. RedissonConfig 리팩토링**

- **개선점:**
  이전 코드에서는 `config.useSingleServer()`가 설정 단계마다 여러 번 호출될 가능성이 있었습니다. 이는 매번 새로운 `SingleServerConfig` 객체를 생성하여 비효율을 유발하고 코드의 의도를 흐리게 할 수 있습니다.

- **수정 내용:**
  `SingleServerConfig` 인스턴스를 지역 변수로 한 번만 선언하고, 이후의 모든 설정(`.setAddress()`, `.setUsername()` 등)을 해당 변수에 대해 체이닝(Chaining)하도록 코드를 리팩토링했습니다.
  - 이 간단한 개선을 통해 불필요한 객체 생성을 막아 미세한 성능 향상을 기대할 수 있으며, 코드가 더 깔끔하고 명확해졌습니다.

#### **3. 향후 개선 제안 (성능 최적화)**

- **대상:** `WaitingQueueScheduler`의 `grantAccessToUsers` 메서드
- **내용:** 현재는 입장 처리될 사용자들에 대한 Redis 명령어(키 생성, 세션 추가 등)를 `for` 루프 내에서 순차적으로 실행하고 있습니다. 이 방식은 로직이 명확하고 부하가 안정적이라는 장점이 있습니다.
- **개선 아이디어:** 만약 향후 한 번에 입장시키는 사용자 수가 수백~수천 명 단위로 매우 많아져, 이 부분의 누적된 네트워크 지연 시간이 병목으로 확인될 경우, **Redisson의 배치(Batch/Pipelining) 모드**를 적용하는 것을 고려할 수 있습니다.
  - **기대 효과:** 수백 개의 Redis 명령어를 단 한 번의 네트워크 요청으로 처리하여, 성능을 극적으로 향상시키면서도 서버에 가해지는 부하는 안정적으로 유지할 수 있습니다.
  - **결론:** 이번 PR에서는 로직의 단순성과 안정성을 우선하여 순차 처리 방식을 유지했으나, 추후 성능 테스트 결과에 따라 **1순위 최적화 과제로 이 '배치 처리' 전환을 검토**할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- 분산 환경에서 대기열 스케줄러의 동시 실행을 방지하기 위해 분산 락이 적용되었습니다.
	- 사용자 입장 처리 및 활성 사용자 수 업데이트가 더 안전하고 효율적으로 개선되었습니다.
	- 코드 내 주석 및 설명이 보강되어 동작 방식이 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->