### PR TITLE
[FIX] JWT Token 검증 및 재발급 로직 수정

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.team03.ticketmon._global.config;
 
+import com.team03.ticketmon.auth.Util.CookieUtil;
 import com.team03.ticketmon.auth.jwt.JwtAuthenticationFilter;
 import com.team03.ticketmon.auth.jwt.JwtTokenProvider;
 import com.team03.ticketmon.auth.jwt.LoginFilter;
@@ -42,6 +43,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final ReissueService reissueService;
     private final RefreshTokenService refreshTokenService;
+    private final CookieUtil cookieUtil;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -86,8 +88,8 @@ public class SecurityConfig {
                 )
 
                 // Login Filter 적용
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, reissueService), LoginFilter.class)
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtTokenProvider, refreshTokenService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, reissueService, cookieUtil), LoginFilter.class)
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtTokenProvider, refreshTokenService, cookieUtil), UsernamePasswordAuthenticationFilter.class)
 
                 // 인증/인가 실패(인증 실패(401), 권한 부족(403)) 시 반환되는 예외 응답 설정
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/team03/ticketmon/auth/Util/CookieUtil.java
+++ b/src/main/java/com/team03/ticketmon/auth/Util/CookieUtil.java
@@ -1,0 +1,31 @@
+package com.team03.ticketmon.auth.Util;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    // 쿠키 생성
+    public ResponseCookie createCookie(String key, String value, Long expiration) {
+        return ResponseCookie.from(key, value)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(expiration) // 밀리초를 초로 변환
+                .sameSite("Lax")
+                .build();
+    }
+
+    // 쿠키 삭제
+    public ResponseCookie deleteCookie(String key) {
+        return ResponseCookie.from(key, "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+    }
+
+}

--- a/src/main/java/com/team03/ticketmon/auth/Util/CookieUtil.java
+++ b/src/main/java/com/team03/ticketmon/auth/Util/CookieUtil.java
@@ -3,6 +3,8 @@ package com.team03.ticketmon.auth.Util;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+
 @Component
 public class CookieUtil {
 
@@ -12,7 +14,7 @@ public class CookieUtil {
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .maxAge(expiration) // 밀리초를 초로 변환
+                .maxAge(Duration.ofMillis(expiration)) // 밀리초를 초로 변환
                 .sameSite("Lax")
                 .build();
     }

--- a/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.team03.ticketmon.auth.jwt;
 
+import com.team03.ticketmon.auth.Util.CookieUtil;
 import com.team03.ticketmon.auth.service.ReissueService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -7,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -18,20 +20,33 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final ReissueService reissueService;
+    private final CookieUtil cookieUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = jwtTokenProvider.getTokenFromCookies(jwtTokenProvider.CATEGORY_ACCESS, request);
         String refreshToken = jwtTokenProvider.getTokenFromCookies(jwtTokenProvider.CATEGORY_REFRESH, request);
 
-        if (isEmpty(accessToken) || isEmpty(refreshToken)) {
-            log.debug("Access 또는 Refresh Token이 존재하지 않음");
+        if (isEmpty(refreshToken)) {
+            if (!isEmpty(accessToken)) {
+                // Access Token이 쿠키에 남아있으면 삭제
+                ResponseCookie accessCookie = cookieUtil.deleteCookie(jwtTokenProvider.CATEGORY_ACCESS);
+                response.addHeader("Set-Cookie", accessCookie.toString());
+            }
+
             filterChain.doFilter(request, response);
             return;
         }
 
         // 만료 여부 확인 및 재발급
-        accessToken = handleTokenReissue(accessToken, refreshToken, response);
+        if (!isEmpty(accessToken) && !jwtTokenProvider.isTokenExpired(accessToken)) {
+            setAuthenticationContext(accessToken);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        accessToken = handleTokenReissue(refreshToken, response);
+
         if (isEmpty(accessToken))
             return;
 
@@ -42,9 +57,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String handleTokenReissue(String accessToken, String refreshToken, HttpServletResponse response) throws IOException {
-        if (!jwtTokenProvider.isTokenExpired(accessToken))
-            return accessToken;
+    private String handleTokenReissue(String refreshToken, HttpServletResponse response) throws IOException {
 
         // Access Token이 만료되었고 Refresh Token 유효성 확인 후 재발급
         log.info("Access Token 만료됨 Refresh Token으로 재발급 시도");
@@ -55,7 +68,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return null;
         }
 
-        response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccessToken));
+        Long accessExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS) / 1000;
+        ResponseCookie accessCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccessToken, accessExp);
+        response.addHeader("Set-Cookie", accessCookie.toString());
+
         return newAccessToken;
     }
 

--- a/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
@@ -61,14 +61,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // Access Token이 만료되었고 Refresh Token 유효성 확인 후 재발급
         log.info("Access Token 만료됨 Refresh Token으로 재발급 시도");
-        String newAccessToken = reissueService.reissueToken(refreshToken, jwtTokenProvider.CATEGORY_ACCESS);
+        String newAccessToken = reissueService.reissueToken(refreshToken, jwtTokenProvider.CATEGORY_ACCESS, true);
         if (isEmpty(newAccessToken)) {
             log.warn("Refresh Token이 유효하지 않음 재로그인 필요");
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh Token이 만료되었거나 유효하지 않습니다.");
             return null;
         }
 
-        Long accessExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS) / 1000;
+        Long accessExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS);
         ResponseCookie accessCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccessToken, accessExp);
         response.addHeader("Set-Cookie", accessCookie.toString());
 

--- a/src/main/java/com/team03/ticketmon/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/JwtTokenProvider.java
@@ -61,16 +61,6 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    // 쿠키 생성
-    public Cookie createCookie(String key, String value) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge((int) getExpirationMs(key));
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        return cookie;
-    }
-
     // JWT용 Secret Key 생성
     public SecretKey getSecretKey() {
         return this.jwtSecretKey;

--- a/src/main/java/com/team03/ticketmon/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/LoginFilter.java
@@ -1,9 +1,11 @@
 package com.team03.ticketmon.auth.jwt;
 
+import com.team03.ticketmon.auth.Util.CookieUtil;
 import com.team03.ticketmon.auth.service.RefreshTokenService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -17,12 +19,13 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
+    private final CookieUtil cookieUtil;
 
-    public LoginFilter(AuthenticationManager authenticationManager, JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService) {
+    public LoginFilter(AuthenticationManager authenticationManager, JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService, CookieUtil cookieUtil) {
         this.authenticationManager = authenticationManager;
         this.jwtTokenProvider = jwtTokenProvider;
         this.refreshTokenService = refreshTokenService;
-
+        this.cookieUtil = cookieUtil;
         setFilterProcessesUrl("/auth/login");
     }
 
@@ -52,8 +55,13 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         refreshTokenService.deleteRefreshToken(userId);
         refreshTokenService.saveRefreshToken(userId, refreshToken);
 
-        response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_ACCESS, accessToken));
-        response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken));
+        Long accessCookieExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS) / 1000;
+        Long refreshCookieExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_REFRESH) / 1000;
+
+        ResponseCookie accessCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_ACCESS, accessToken, accessCookieExp);
+        ResponseCookie refreshCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken, refreshCookieExp);
+        response.addHeader("Set-Cookie", accessCookie.toString());
+        response.addHeader("Set-Cookie", refreshCookie.toString());
         response.setStatus(HttpServletResponse.SC_OK);
     }
 

--- a/src/main/java/com/team03/ticketmon/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/LoginFilter.java
@@ -55,8 +55,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         refreshTokenService.deleteRefreshToken(userId);
         refreshTokenService.saveRefreshToken(userId, refreshToken);
 
-        Long accessCookieExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS) / 1000;
-        Long refreshCookieExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_REFRESH) / 1000;
+        Long accessCookieExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS);
+        Long refreshCookieExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_REFRESH);
 
         ResponseCookie accessCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_ACCESS, accessToken, accessCookieExp);
         ResponseCookie refreshCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken, refreshCookieExp);

--- a/src/main/java/com/team03/ticketmon/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/team03/ticketmon/auth/repository/RefreshTokenRepository.java
@@ -1,7 +1,6 @@
 package com.team03.ticketmon.auth.repository;
 
 import com.team03.ticketmon.auth.domain.entity.RefreshToken;
-import com.team03.ticketmon.user.domain.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +9,5 @@ import java.util.Optional;
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     void deleteByUserEntityId(Long userId);
-    Optional<RefreshToken> findByUserEntity(UserEntity user);
+    Optional<String> findRefreshTokenByUserEntityIdAndToken(Long userId, String token);
 }

--- a/src/main/java/com/team03/ticketmon/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/team03/ticketmon/auth/repository/RefreshTokenRepository.java
@@ -2,12 +2,17 @@ package com.team03.ticketmon.auth.repository;
 
 import com.team03.ticketmon.auth.domain.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    void deleteByUserEntityId(Long userId);
-    Optional<String> findRefreshTokenByUserEntityIdAndToken(Long userId, String token);
+    @Modifying
+    @Query("delete from RefreshToken r where r.userEntity.id = :userId")
+    void deleteByUserEntityId(@Param("userId") Long userId);
+
+    @Query("select COUNT(r) > 0 from RefreshToken r where r.userEntity.id = :userId and r.token = :token")
+    boolean existsByUserEntityIdAndToken(@Param("userId") Long userId, @Param("token") String token);
 }

--- a/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenService.java
@@ -1,8 +1,9 @@
 package com.team03.ticketmon.auth.service;
 
-import com.team03.ticketmon.user.domain.entity.UserEntity;
+import java.util.Optional;
 
 public interface RefreshTokenService {
     void deleteRefreshToken(Long userId);
     void saveRefreshToken(Long userId, String token);
+    Optional<String> findRefreshToken(Long userId, String token);
 }

--- a/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenService.java
@@ -1,9 +1,7 @@
 package com.team03.ticketmon.auth.service;
 
-import java.util.Optional;
-
 public interface RefreshTokenService {
     void deleteRefreshToken(Long userId);
     void saveRefreshToken(Long userId, String token);
-    Optional<String> findRefreshToken(Long userId, String token);
+    boolean existToken(Long userId, String token);
 }

--- a/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -34,6 +35,11 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
                 .build();
 
         refreshTokenRepository.save(refreshToken);
+    }
+
+    @Override
+    public Optional<String> findRefreshToken(Long userId, String token) {
+        return refreshTokenRepository.findRefreshTokenByUserEntityIdAndToken(userId, token);
     }
 
     @Override

--- a/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenServiceImpl.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -38,8 +37,8 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     }
 
     @Override
-    public Optional<String> findRefreshToken(Long userId, String token) {
-        return refreshTokenRepository.findRefreshTokenByUserEntityIdAndToken(userId, token);
+    public boolean existToken(Long userId, String token) {
+        return refreshTokenRepository.existsByUserEntityIdAndToken(userId, token);
     }
 
     @Override

--- a/src/main/java/com/team03/ticketmon/auth/service/ReissueService.java
+++ b/src/main/java/com/team03/ticketmon/auth/service/ReissueService.java
@@ -4,6 +4,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface ReissueService {
-    String reissueToken(String refreshToken, String reissueCategory);
+    String reissueToken(String refreshToken, String reissueCategory, boolean dbCheck);
     void handleReissueToken(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/resources/static/auth/register.html
+++ b/src/main/resources/static/auth/register.html
@@ -74,18 +74,23 @@
             address: document.getElementById('address').value
         };
 
-        await fetch('/auth/register', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify(data)
-        })
-            .then(res => {
-                if (res.ok) {
-                    window.location.href = "login.html";
-                } else {
-                    document.getElementById('error-message').innerText = res.body();
-                }
-            })
+        try {
+            const res = await fetch('/auth/register', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(data)
+            });
+
+            if (res.ok) {
+                window.location.href = "/auth/login";
+                return;
+            }
+
+            const errText = await res.text();
+            document.getElementById('error-message').innerHTML = errText;
+        } catch (e) {
+            document.getElementById('error-message').innerHTML = '네트워크 오류가 발생했습니다.'
+        }
     });
 </script>
 


### PR DESCRIPTION
### 1. [기능명] 구현/수정

[FIX] JWT Token 검증 및 재발급 로직 수정

### 2. 작업 내용

<!-- 이번 PR에서 구현한 기능(세부적인 기능 포함)을 간단히 설명해주세요 -->

- [x]  JWT Refresh Token 검증 시 DB에 Refresh Token 데이터 확인
- [x]  Cookie에 저장된 토큰은 만료 시 자동 삭제로 이에 따른 검증 로직 수정
- [x]  Cookie 생성 로직을 분리하여 CookieUtil에서 수행
- [x]  이전 PR 리뷰 반영 (https://github.com/AIBE-3Team/AIBE1-FinalProject-Team03/pull/22)
- CookieUtil : maxAge Duration 설정
- RefreshTokenService : 토큰 조회는 토큰 존재 여부만 확인 필요함으로 boolean으로 변경
- ReissueService : Access Token 재발급 과정에서 Refresh Token 검증 시 DB 확인하도록 수정
- RefreshTokenRepository : RefreshToken 조회 및 삭제 과정에서 불필요한 UserEntity 조인 수정

### 3. 주요 변경사항

<!-- 코드의 핵심 변경사항을 설명해주세요 -->

- **새로 추가된 파일**:
- **수정된 파일**:
- **삭제된 파일**:

### 4. 관련 이슈

<!-- 관련된 GitHub 이슈가 있다면 링크해주세요 -->

- Closes #이슈번호
- Related to #이슈번호

### 5. 보안 확인사항

- [x]  Refresh Token 검증 시 jwt 토큰 유효성과 DB 토큰 데이터 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 보안 강화를 위해 쿠키 생성 및 삭제를 위한 CookieUtil 유틸리티가 도입되었습니다.
    - 리프레시 토큰의 존재 여부를 확인하는 기능이 추가되었습니다.

- **버그 수정**
    - 회원가입 페이지에서 네트워크 오류 및 서버 오류 메시지 처리가 개선되었습니다.

- **리팩터링**
    - 인증 및 토큰 재발급 과정에서 쿠키 처리가 Spring ResponseCookie 방식으로 일원화되었습니다.
    - 토큰 재발급 시 데이터베이스 검증 로직이 추가되어, 더 안전하게 토큰이 관리됩니다.

- **테스트**
    - 쿠키 처리 방식 변경과 토큰 검증 강화에 맞춰 테스트 코드가 보완되었습니다.
    - 리프레시 토큰이 존재하지 않을 때의 예외 상황 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->