### PR TITLE
[FEAT] Logout 구현 및 토큰 유효성 검증 메소드 이동

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
@@ -106,14 +106,6 @@ public class SecurityConfig {
                         })
                 );
 
-                // 로그아웃 시 세션 무효화 및 쿠키 삭제 설정 (JWT 기반에서는 토큰 무효화 로직은 따로 구현해야 함)
-                // .logout(logout -> logout
-                //         .logoutUrl("/auth/logout")   // 로그아웃 요청 경로
-                //         .invalidateHttpSession(true)    // 세션 무효화 (거의 의미 없음. JWT라서)
-                //         .deleteCookies("JSESSIONID", "jwt_token")   // 쿠키 삭제
-                //         .permitAll()
-                // );
-
         return http.build();
     }
 

--- a/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.team03.ticketmon.auth.Util.CookieUtil;
 import com.team03.ticketmon.auth.jwt.JwtAuthenticationFilter;
 import com.team03.ticketmon.auth.jwt.JwtTokenProvider;
 import com.team03.ticketmon.auth.jwt.LoginFilter;
+import com.team03.ticketmon.auth.jwt.CustomLogoutFilter;
 import com.team03.ticketmon.auth.service.RefreshTokenService;
 import com.team03.ticketmon.auth.service.ReissueService;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,6 +22,7 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -89,6 +91,7 @@ public class SecurityConfig {
 
                 // Login Filter 적용
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, reissueService, cookieUtil), LoginFilter.class)
+                .addFilterBefore(new CustomLogoutFilter(jwtTokenProvider, refreshTokenService, cookieUtil), LogoutFilter.class)
                 .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtTokenProvider, refreshTokenService, cookieUtil), UsernamePasswordAuthenticationFilter.class)
 
                 // 인증/인가 실패(인증 실패(401), 권한 부족(403)) 시 반환되는 예외 응답 설정
@@ -101,15 +104,15 @@ public class SecurityConfig {
                             response.setStatus(HttpServletResponse.SC_FORBIDDEN);   // 403
                             response.getWriter().write("Access Denied: " + accessDeniedException.getMessage());
                         })
-                )
+                );
 
                 // 로그아웃 시 세션 무효화 및 쿠키 삭제 설정 (JWT 기반에서는 토큰 무효화 로직은 따로 구현해야 함)
-                .logout(logout -> logout
-                        .logoutUrl("/logout")   // 로그아웃 요청 경로
-                        .invalidateHttpSession(true)    // 세션 무효화 (거의 의미 없음. JWT라서)
-                        .deleteCookies("JSESSIONID", "jwt_token")   // 쿠키 삭제
-                        .permitAll()
-                );
+                // .logout(logout -> logout
+                //         .logoutUrl("/auth/logout")   // 로그아웃 요청 경로
+                //         .invalidateHttpSession(true)    // 세션 무효화 (거의 의미 없음. JWT라서)
+                //         .deleteCookies("JSESSIONID", "jwt_token")   // 쿠키 삭제
+                //         .permitAll()
+                // );
 
         return http.build();
     }

--- a/src/main/java/com/team03/ticketmon/auth/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/CustomLogoutFilter.java
@@ -1,0 +1,63 @@
+package com.team03.ticketmon.auth.jwt;
+
+import com.team03.ticketmon.auth.Util.CookieUtil;
+import com.team03.ticketmon.auth.service.RefreshTokenService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final CookieUtil cookieUtil;
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        if (isLogoutRequest(request)) {
+            handleLogout(request, response);
+        } else {
+            filterChain.doFilter(request, response);
+        }
+    }
+
+    private void handleLogout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = jwtTokenProvider.getTokenFromCookies(jwtTokenProvider.CATEGORY_REFRESH, request);
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        try {
+            Long userId = jwtTokenProvider.getUserId(refreshToken);
+
+            refreshTokenService.validateRefreshToken(refreshToken, true);
+            refreshTokenService.deleteRefreshToken(userId);
+            cookieUtil.deleteCookie(jwtTokenProvider.CATEGORY_ACCESS);
+            cookieUtil.deleteCookie(jwtTokenProvider.CATEGORY_REFRESH);
+
+            response.setStatus(HttpServletResponse.SC_OK);
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        }
+    }
+
+    private boolean isLogoutRequest(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        String requestMethod = request.getMethod();
+
+        return "/auth/logout".equals(requestUri) && "POST".equals(requestMethod);
+    }
+}

--- a/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenService.java
@@ -4,4 +4,5 @@ public interface RefreshTokenService {
     void deleteRefreshToken(Long userId);
     void saveRefreshToken(Long userId, String token);
     boolean existToken(Long userId, String token);
+    void validateRefreshToken(String refreshToken, boolean dbCheck);
 }

--- a/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/auth/service/RefreshTokenServiceImpl.java
@@ -46,6 +46,22 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
         refreshTokenRepository.deleteByUserEntityId(userId);
     }
 
+    @Override
+    public void validateRefreshToken(String refreshToken, boolean dbCheck) {
+        String category = jwtTokenProvider.getCategory(refreshToken);
+        if (!jwtTokenProvider.CATEGORY_REFRESH.equals(category))
+            throw new IllegalArgumentException("유효하지 않은 카테고리 JWT 토큰입니다.");
+
+        if (jwtTokenProvider.isTokenExpired(refreshToken))
+            throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
+
+        if (dbCheck) {
+            Long userId = jwtTokenProvider.getUserId(refreshToken);
+            if (!existToken(userId, refreshToken))
+                throw new IllegalArgumentException("Refresh Token이 DB에 존재하지 않습니다.");
+        }
+    }
+
     private LocalDateTime getExpirationTime() {
         Instant now = Instant.now();
         Instant expirationInstant = now.plusMillis(jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_REFRESH));

--- a/src/main/java/com/team03/ticketmon/auth/service/ReissueServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/auth/service/ReissueServiceImpl.java
@@ -22,7 +22,7 @@ public class ReissueServiceImpl implements ReissueService {
 
     @Override
     public String reissueToken(String refreshToken, String reissueCategory, boolean dbCheck) {
-        validateRefreshToken(refreshToken, dbCheck);
+        refreshTokenService.validateRefreshToken(refreshToken, dbCheck);
         Long userId = jwtTokenProvider.getUserId(refreshToken);
         String role = extractRole(refreshToken);
         return jwtTokenProvider.generateToken(reissueCategory, userId, role);
@@ -36,7 +36,7 @@ public class ReissueServiceImpl implements ReissueService {
 
         Long userId = jwtTokenProvider.getUserId(refreshToken);
 
-        validateRefreshToken(refreshToken, true);
+        refreshTokenService.validateRefreshToken(refreshToken, true);
 
         String newAccessToken = reissueToken(refreshToken, jwtTokenProvider.CATEGORY_ACCESS, false);
         String newRefreshToken = reissueToken(refreshToken, jwtTokenProvider.CATEGORY_REFRESH, false);
@@ -58,21 +58,6 @@ public class ReissueServiceImpl implements ReissueService {
         ResponseCookie refreshCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_REFRESH, newRefreshToken, refreshCookieExp);
         response.addHeader("Set-Cookie", accessCookie.toString());
         response.addHeader("Set-Cookie", refreshCookie.toString());
-    }
-
-    private void validateRefreshToken(String refreshToken, boolean dbCheck) {
-        String category = jwtTokenProvider.getCategory(refreshToken);
-        if (!jwtTokenProvider.CATEGORY_REFRESH.equals(category))
-            throw new IllegalArgumentException("유효하지 않은 카테고리 JWT 토큰입니다.");
-
-        if (jwtTokenProvider.isTokenExpired(refreshToken))
-            throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
-
-        if (dbCheck) {
-            Long userId = jwtTokenProvider.getUserId(refreshToken);
-            if (!refreshTokenService.existToken(userId, refreshToken))
-                throw new IllegalArgumentException("Refresh Token이 DB에 존재하지 않습니다.");
-        }
     }
 
     private String extractRole(String token) {


### PR DESCRIPTION
1. [기능명] 구현/수정
[FEAT] Logout 구현 및 토큰 유효성 검증 메소드 이동

2. 작업 내용
- [x]  Custom Logout Filter 구현 (요청 URL : /auth/logout, Method : POST)
- [x]  토큰 유효성 검증 메소드 이동 (ReissueService -> RefreshTokenService)

3. 주요 변경사항
새로 추가된 파일:
src/main/java/com/team03/ticketmon/auth/jwt/CustomLogoutFilter.java 
수정된 파일:
src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
src/main/java/com/team03/ticketmon/auth/service/RefreshTokenService.java
src/main/java/com/team03/ticketmon/auth/service/RefreshTokenServiceImpl.java
src/main/java/com/team03/ticketmon/auth/service/ReissueServiceImpl.java
src/test/java/com/team03/ticketmon/auth/service/RefreshTokenServiceImplTest.java
src/test/java/com/team03/ticketmon/auth/service/ReissueServiceImplTest.java
삭제된 파일:

4. 관련 이슈
Closes #이슈번호
Related to #이슈번호

5. 보안 확인사항
- [x]  