### PR TITLE
 [FIX] JWT 토큰 생성 및 쿠키 설정 로직 리팩토링

### DIFF
--- a/src/main/java/com/team03/ticketmon/auth/Util/CookieUtil.java
+++ b/src/main/java/com/team03/ticketmon/auth/Util/CookieUtil.java
@@ -1,12 +1,20 @@
 package com.team03.ticketmon.auth.Util;
 
+import com.team03.ticketmon.auth.jwt.JwtTokenProvider;
+import com.team03.ticketmon.auth.service.RefreshTokenService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 
 @Component
+@RequiredArgsConstructor
 public class CookieUtil {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     // 쿠키 생성
     public ResponseCookie createCookie(String key, String value, Long expiration) {
@@ -30,4 +38,40 @@ public class CookieUtil {
                 .build();
     }
 
+    // Access Token과 Refresh Token 쿠키 생성
+    public void generateAndSetJwtCookies(Long userId, String username, String role, HttpServletResponse response) {
+        String newAccessToken = generateAccessToken(userId, username, role);
+        String newRefreshToken = generateRefreshTokenAndSave(userId, username, role);
+
+        if(newAccessToken == null || newAccessToken.isEmpty())
+            throw new IllegalArgumentException("Access Token 재발급이 실패했습니다.");
+        if(newRefreshToken == null || newRefreshToken.isEmpty())
+            throw new IllegalArgumentException("Refresh Token 재발급이 실패했습니다.");
+
+        ResponseCookie accessCookie = createJwtCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccessToken);
+        ResponseCookie refreshCookie = createJwtCookie(jwtTokenProvider.CATEGORY_REFRESH, newRefreshToken);
+
+        addJwtCookiesToResponse(accessCookie, refreshCookie, response);
+    }
+
+    private String generateAccessToken(Long userId, String username, String role) {
+        return jwtTokenProvider.generateToken(jwtTokenProvider.CATEGORY_ACCESS, userId, username, role);
+    }
+
+    private String generateRefreshTokenAndSave(Long userId, String username, String role) {
+        String newRefreshToken = jwtTokenProvider.generateToken(jwtTokenProvider.CATEGORY_REFRESH, userId, username, role);
+        refreshTokenService.deleteRefreshToken(userId);
+        refreshTokenService.saveRefreshToken(userId, newRefreshToken);
+        return newRefreshToken;
+    }
+
+    private ResponseCookie createJwtCookie(String category, String token) {
+        Long expiration = jwtTokenProvider.getExpirationMs(category);
+        return createCookie(category, token, expiration);
+    }
+
+    private void addJwtCookiesToResponse(ResponseCookie accessCookie, ResponseCookie refreshCookie, HttpServletResponse response) {
+        response.addHeader("Set-Cookie", accessCookie.toString());
+        response.addHeader("Set-Cookie", refreshCookie.toString());
+    }
 }

--- a/src/main/java/com/team03/ticketmon/auth/jwt/CustomUserDetails.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/CustomUserDetails.java
@@ -1,28 +1,18 @@
 package com.team03.ticketmon.auth.jwt;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 
 @Getter
+@RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
     private final Long userId;
     private final String username;
     private final String password;
     private final Collection<? extends GrantedAuthority> authorities;
-
-    public CustomUserDetails(Long userId, String username, String password, Collection<? extends GrantedAuthority> authorities) {
-        this.userId = userId;
-        this.username = username;
-        this.password = password;
-        this.authorities = authorities;
-    }
-
-    @Override public boolean isAccountNonExpired() { return true; }
-    @Override public boolean isAccountNonLocked() { return true; }
-    @Override public boolean isCredentialsNonExpired() { return true; }
-    @Override public boolean isEnabled() { return true; }
 }

--- a/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
@@ -71,7 +71,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Long accessExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS);
         ResponseCookie accessCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccessToken, accessExp);
         response.addHeader("Set-Cookie", accessCookie.toString());
-
         return newAccessToken;
     }
 

--- a/src/main/java/com/team03/ticketmon/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/JwtTokenProvider.java
@@ -29,6 +29,7 @@ public class JwtTokenProvider {
     public final String CATEGORY_REFRESH = "refresh";
     private static final String CLAIM_CATEGORY = "category";
     private static final String CLAIM_USERID = "userid";
+    private static final String CLAIM_USERNAME = "username";
     private static final String CLAIM_ROLE = "role";
 
     @Value("${jwt.secret}")
@@ -46,14 +47,14 @@ public class JwtTokenProvider {
     }
 
     // JWT Token 생성
-    public String generateToken(String category, Long userId, String role) {
-
+    public String generateToken(String category, Long userId, String username, String role) {
         Instant now = Instant.now();
         Date expiration = new Date(now.toEpochMilli() + getExpirationMs(category));
 
         return Jwts.builder()
                 .claim(CLAIM_CATEGORY, category)
                 .claim(CLAIM_USERID, userId)
+                .claim(CLAIM_USERNAME, username)
                 .claim(CLAIM_ROLE, role)
                 .issuedAt(Date.from(now))
                 .expiration(expiration)
@@ -70,7 +71,7 @@ public class JwtTokenProvider {
         try {
             return parseClaims(token).get(CLAIM_CATEGORY, String.class);
         } catch (JwtException e) {
-            throw new BadCredentialsException("유효하지 않은 카테고리 JWT 토큰입니다.", e);
+            throw new BadCredentialsException("JWT 토큰의 카테고리 형식이 유효하지 않습니다.", e);
         }
     }
 
@@ -78,7 +79,15 @@ public class JwtTokenProvider {
         try {
             return parseClaims(token).get(CLAIM_USERID, Long.class);
         } catch (JwtException e) {
-            throw new BadCredentialsException("유효하지 않은 아이디 JWT 토큰입니다.", e);
+            throw new BadCredentialsException("JWT 토큰의 UserId 형식이 유효하지 않습니다.", e);
+        }
+    }
+
+    public String getUsername(String token) {
+        try {
+            return parseClaims(token).get(CLAIM_USERNAME, String.class);
+        } catch (JwtException e) {
+            throw new BadCredentialsException("JWT 토큰의 Username 형식이 유효하지 않습니다.", e);
         }
     }
 
@@ -120,12 +129,12 @@ public class JwtTokenProvider {
     }
 
     public Authentication getAuthentication(String token) {
-        Long userId = getUserId(token);
+        String username = getUsername(token);
         List<SimpleGrantedAuthority> authorities = getRoles(token).stream()
                 .map(SimpleGrantedAuthority::new)
                 .toList();
 
-        UserDetails user = new User(userId.toString(), "", authorities);
+        UserDetails user = new User(username, "", authorities);
         return new UsernamePasswordAuthenticationToken(user, null, authorities);
     }
 

--- a/src/main/java/com/team03/ticketmon/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/JwtTokenProvider.java
@@ -129,12 +129,13 @@ public class JwtTokenProvider {
     }
 
     public Authentication getAuthentication(String token) {
+        Long userid = getUserId(token);
         String username = getUsername(token);
         List<SimpleGrantedAuthority> authorities = getRoles(token).stream()
                 .map(SimpleGrantedAuthority::new)
                 .toList();
 
-        UserDetails user = new User(username, "", authorities);
+        CustomUserDetails user = new CustomUserDetails(userid, username, "", authorities);
         return new UsernamePasswordAuthenticationToken(user, null, authorities);
     }
 

--- a/src/main/java/com/team03/ticketmon/auth/service/ReissueServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/auth/service/ReissueServiceImpl.java
@@ -5,7 +5,6 @@ import com.team03.ticketmon.auth.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,8 +23,9 @@ public class ReissueServiceImpl implements ReissueService {
     public String reissueToken(String refreshToken, String reissueCategory, boolean dbCheck) {
         refreshTokenService.validateRefreshToken(refreshToken, dbCheck);
         Long userId = jwtTokenProvider.getUserId(refreshToken);
+        String username = jwtTokenProvider.getUsername(refreshToken);
         String role = extractRole(refreshToken);
-        return jwtTokenProvider.generateToken(reissueCategory, userId, role);
+        return jwtTokenProvider.generateToken(reissueCategory, userId, username, role);
     }
 
     @Override
@@ -35,29 +35,14 @@ public class ReissueServiceImpl implements ReissueService {
             throw new IllegalArgumentException("Refresh Token이 존재하지 않습니다.");
 
         Long userId = jwtTokenProvider.getUserId(refreshToken);
+        String username = jwtTokenProvider.getUsername(refreshToken);
+        String role = extractRole(refreshToken);
 
         refreshTokenService.validateRefreshToken(refreshToken, true);
 
-        String newAccessToken = reissueToken(refreshToken, jwtTokenProvider.CATEGORY_ACCESS, false);
-        String newRefreshToken = reissueToken(refreshToken, jwtTokenProvider.CATEGORY_REFRESH, false);
+        cookieUtil.generateAndSetJwtCookies(userId, username, role, response);
 
-        if(newAccessToken == null || newAccessToken.isEmpty())
-            throw new IllegalArgumentException("Access Token 재발급이 실패했습니다.");
-        if(newRefreshToken == null || newRefreshToken.isEmpty())
-            throw new IllegalArgumentException("Refresh Token 재발급이 실패했습니다.");
-
-        // 기존 Refresh Token 삭제 후 New Refresh Token DB 저장
-        refreshTokenService.deleteRefreshToken(userId);
-        refreshTokenService.saveRefreshToken(userId, newRefreshToken);
-
-        // 새로운 토큰 쿠키에 추가
-        Long accessCookieExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS);
-        Long refreshCookieExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_REFRESH);
-
-        ResponseCookie accessCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccessToken, accessCookieExp);
-        ResponseCookie refreshCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_REFRESH, newRefreshToken, refreshCookieExp);
-        response.addHeader("Set-Cookie", accessCookie.toString());
-        response.addHeader("Set-Cookie", refreshCookie.toString());
+        response.setStatus(HttpServletResponse.SC_OK);
     }
 
     private String extractRole(String token) {


### PR DESCRIPTION
# [JWT] 토큰 생성 및 쿠키 설정 로직 리팩토링

## 작업 내용
* [x] JWT 토큰에 username 클레임 추가
* [x] CookieUtil에 JWT 쿠키 생성 통합 메소드 구현
* [x] 중복된 토큰 생성/쿠키 설정 코드 제거
* [x] CustomUserDetails 생성자 중복 제거
* [x] 에러 메시지 개선 및 통일
* [x] 테스트 코드 리팩토링

## 주요 변경사항

### **수정된 파일**:
* **CookieUtil.java**: 
  - `generateAndSetJwtCookies()` 메소드 추가로 JWT 쿠키 생성 로직 통합
  - Access Token과 Refresh Token 생성부터 쿠키 설정까지 일괄 처리
  
* **JwtTokenProvider.java**:
  - `generateToken()` 메소드에 username 파라미터 추가
  - `getUsername()` 메소드 추가
  - JWT 토큰에 username 클레임 포함
  - 에러 메시지 통일 및 개선

* **LoginFilter.java**:
  - 중복된 토큰 생성 및 쿠키 설정 코드 제거
  - `cookieUtil.generateAndSetJwtCookies()` 사용으로 단순화

* **OAuth2LoginSuccessHandler.java**:
  - 중복된 토큰 생성 및 쿠키 설정 코드 제거
  - `cookieUtil.generateAndSetJwtCookies()` 사용으로 단순화

* **ReissueServiceImpl.java**:
  - 토큰 재발급 로직에서 중복 코드 제거
  - `cookieUtil.generateAndSetJwtCookies()` 사용으로 단순화

* **CustomUserDetails.java**:
  - 중복된 생성자 제거
  - Lombok `@RequiredArgsConstructor` 활용

* **JwtAuthenticationFilter.java**:
  - 불필요한 빈 줄 제거

### **테스트 파일**:
* **ReissueServiceImplTest.java**:
  - 리팩토링된 로직에 맞춘 테스트 코드 수정
  - CookieUtil 의존성 주입 방식 변경
  - 테스트 검증 로직 단순화

## 개선 효과
1. **코드 중복 제거**: 토큰 생성 및 쿠키 설정 로직을 CookieUtil로 통합
2. **유지보수성 향상**: 토큰 관련 로직이 한 곳에 집중되어 수정이 용이
3. **일관성 개선**: JWT 토큰에 username 정보 추가로 인증 정보 완성도 향상
4. **에러 처리 개선**: 더 명확하고 일관된 에러 메시지 제공

## 관련 이슈
* Related to #이슈번호

## 보안 확인사항
* [x] JWT 토큰 생성 시 민감정보 적절히 처리
* [x] 토큰 재발급 시 기존 토큰 무효화 처리
* [x] 에러 핸들링 시 내부 정보 노출 방지
* [x] 쿠키 보안 설정 유지 (HttpOnly, Secure, Path 등)

## 테스트 결과
* [x] 기존 인증 플로우 정상 동작 확인
* [x] 토큰 재발급 로직 정상 동작 확인
* [x] 단위 테스트 통과
* [x] 통합 테스트 통과

## 추가 검토 사항
- 기존 클라이언트에서 JWT 토큰의 username 클레임 사용 여부 확인 필요
- 토큰 파싱 로직에서 username 클레임 누락 시 대응 방안 검토

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - JWT 토큰에 username 클레임이 추가되어 인증 및 토큰 재발급 시 사용자명을 활용할 수 있습니다.

- **버그 수정**
    - 토큰 재발급 및 쿠키 생성 과정이 단일 메서드로 통합되어 예외 상황에 대한 처리가 강화되었습니다.

- **리팩터링**
    - 인증 및 로그인 성공, 토큰 재발급 로직이 CookieUtil의 메서드로 일원화되어 코드가 간결해졌습니다.
    - UserDetails 관련 불필요한 메서드 및 생성자 코드가 정리되었습니다.

- **테스트**
    - 토큰 재발급 테스트가 새로운 username 파라미터와 쿠키 생성 방식에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->